### PR TITLE
fix compose type overloads

### DIFF
--- a/src/ghc/base/functions.ts
+++ b/src/ghc/base/functions.ts
@@ -36,10 +36,10 @@ export function compose<T0 extends unknown[], T1, T2>(f1: (x: T1) => T2, f0: (..
 export function compose<T0, T1, T2, T3>(f2: (x: T2) => T3, f1: (x: T1) => T2, f0: (x: T0) => T1): (x: T0) => T3
 
 export function compose<T0 extends unknown[], T1, T2, T3>(
-    f2: (x: T3) => T3,
+    f2: (x: T2) => T3,
     f1: (x: T1) => T2,
     f0: (...args: T0) => T1,
-): (...args: T0) => T2
+): (...args: T0) => T3
 
 export function compose<T0, T1, T2, T3, T4>(
     f3: (x: T3) => T4,
@@ -66,7 +66,7 @@ export function compose<T0, T1, T2, T3, T4, T5, T6>(
 ): (x: T0) => T6
 
 export function compose<T0, T1, T2, T3, T4, T5, T6, T7>(
-    f6: (x: T5) => T7,
+    f6: (x: T6) => T7,
     f5: (x: T5) => T6,
     f4: (x: T4) => T5,
     f3: (x: T3) => T4,

--- a/test/ghc/base/functions/compose.test.ts
+++ b/test/ghc/base/functions/compose.test.ts
@@ -1,0 +1,17 @@
+import tap from 'tap'
+import { compose } from 'ghc/base/functions'
+
+tap.test('compose', async (t) => {
+    t.test('compose seven functions', async (t) => {
+        const f0 = (x: number) => x + 1
+        const f1 = (x: number) => x * 2
+        const f2 = (x: number) => x - 3
+        const f3 = (x: number) => x * x
+        const f4 = (x: number) => x - 10
+        const f5 = (x: number) => x / 2
+        const f6 = (x: number) => x.toString()
+
+        const result = compose(f6, f5, f4, f3, f2, f1, f0)(3)
+        t.equal(result, '7.5')
+    })
+})

--- a/test/ghc/base/maybe/semigroup.test.ts
+++ b/test/ghc/base/maybe/semigroup.test.ts
@@ -34,7 +34,7 @@ tap.test('MaybeSemigroup', async (t) => {
     })
 
     t.test('sconcat', async (t) => {
-        const value1 = compose(formList, cons(nothing()), nil)(id)
+        const value1 = compose(formList, cons(nothing()), nil)()
         const value2 = compose(formList, cons(nothing()), cons(nothing()), nil)(id)
 
         const value3 = compose(


### PR DESCRIPTION
## Summary
- correct compose() overloads for three and seven function chains
- cover seven-function composition with a dedicated test
- adjust Maybe semigroup tests for updated compose signature

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68983f53ff108328a6b28f766b43506d