### PR TITLE
Fix compose overload f6 parameter type

### DIFF
--- a/src/ghc/base/functions.ts
+++ b/src/ghc/base/functions.ts
@@ -66,7 +66,7 @@ export function compose<T0, T1, T2, T3, T4, T5, T6>(
 ): (x: T0) => T6
 
 export function compose<T0, T1, T2, T3, T4, T5, T6, T7>(
-    f6: (x: T5) => T7,
+    f6: (x: T6) => T7,
     f5: (x: T5) => T6,
     f4: (x: T4) => T5,
     f3: (x: T3) => T4,


### PR DESCRIPTION
## Summary
- correct the last compose overload's `f6` parameter to accept `T6`

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689845591f208328aca48dc3f5902f94