### PR TITLE
test: add curry tuple test

### DIFF
--- a/test/ghc/base/tuple/tuple.test.ts
+++ b/test/ghc/base/tuple/tuple.test.ts
@@ -1,0 +1,10 @@
+import tap from 'tap'
+import { curry } from 'ghc/base/tuple/tuple'
+
+tap.test('curry', async (t) => {
+    const add = (x: number, y: number): number => x + y
+    const curriedAdd = curry(add)
+
+    t.equal(curriedAdd(1)(2), 3)
+    t.equal(add(1, 2), 3)
+})


### PR DESCRIPTION
## Summary
- add unit test for tuple curry ensuring curried and uncurried forms produce same result

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898461ced688328ad1cef9e0ab3cda7