### PR TITLE
Fix compose overload typing

### DIFF
--- a/src/ghc/base/functions.ts
+++ b/src/ghc/base/functions.ts
@@ -38,39 +38,39 @@ export function compose<T0 extends unknown[], T1, T2, T3>(
     f1: (x: T1) => T2,
     f0: (...args: T0) => T1,
 ): (...args: T0) => T3
-export function compose<T0, T1, T2, T3, T4>(
+export function compose<T0 extends unknown[], T1, T2, T3, T4>(
     f3: (x: T3) => T4,
     f2: (x: T2) => T3,
     f1: (x: T1) => T2,
-    f0: (x: T0) => T1,
-): (x: T0) => T4
+    f0: (...args: T0) => T1,
+): (...args: T0) => T4
 
-export function compose<T0, T1, T2, T3, T4, T5>(
+export function compose<T0 extends unknown[], T1, T2, T3, T4, T5>(
     f4: (x: T4) => T5,
     f3: (x: T3) => T4,
     f2: (x: T2) => T3,
     f1: (x: T1) => T2,
-    f0: (x: T0) => T1,
-): (x: T0) => T5
+    f0: (...args: T0) => T1,
+): (...args: T0) => T5
 
-export function compose<T0, T1, T2, T3, T4, T5, T6>(
+export function compose<T0 extends unknown[], T1, T2, T3, T4, T5, T6>(
     f5: (x: T5) => T6,
     f4: (x: T4) => T5,
     f3: (x: T3) => T4,
     f2: (x: T2) => T3,
     f1: (x: T1) => T2,
-    f0: (x: T0) => T1,
-): (x: T0) => T6
+    f0: (...args: T0) => T1,
+): (...args: T0) => T6
 
-export function compose<T0, T1, T2, T3, T4, T5, T6, T7>(
+export function compose<T0 extends unknown[], T1, T2, T3, T4, T5, T6, T7>(
     f6: (x: T6) => T7,
     f5: (x: T5) => T6,
     f4: (x: T4) => T5,
     f3: (x: T3) => T4,
     f2: (x: T2) => T3,
     f1: (x: T1) => T2,
-    f0: (x: T0) => T1,
-): (x: T0) => T7
+    f0: (...args: T0) => T1,
+): (...args: T0) => T7
 
 export function compose(...fns: Func[]) {
     return (...args: unknown[]) => fns.reduceRight((res, fn) => [fn.call(null, ...res)], args)[0]

--- a/src/ghc/base/functions.ts
+++ b/src/ghc/base/functions.ts
@@ -33,14 +33,11 @@ export function compose<T0, T1, T2>(f1: (x: T1) => T2, f0: (x: T0) => T1): (x: T
 
 export function compose<T0 extends unknown[], T1, T2>(f1: (x: T1) => T2, f0: (...args: T0) => T1): (...args: T0) => T2
 
-export function compose<T0, T1, T2, T3>(f2: (x: T2) => T3, f1: (x: T1) => T2, f0: (x: T0) => T1): (x: T0) => T3
-
 export function compose<T0 extends unknown[], T1, T2, T3>(
     f2: (x: T2) => T3,
     f1: (x: T1) => T2,
     f0: (...args: T0) => T1,
 ): (...args: T0) => T3
-
 export function compose<T0, T1, T2, T3, T4>(
     f3: (x: T3) => T4,
     f2: (x: T2) => T3,


### PR DESCRIPTION
## Summary
- streamline compose overload to rest-args variant
- ensure final stage returns `T3` from `T2` to align composition types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68984869c664832894758c267fa55c6e