### PR TITLE
Use explicit tuple elements in compose calls

### DIFF
--- a/src/ghc/base/tuple/tuple2-applicative.ts
+++ b/src/ghc/base/tuple/tuple2-applicative.ts
@@ -48,7 +48,7 @@ const baseImplementation = <T>(monoid: Monoid<T>): BaseImplementation => ({
         const uv = monoid['<>'](fst(fa), fst(fb))
 
         // tuple2(uv, f(snd(fa))(snd(fb)))
-        return compose<Tuple2BoxT<T, B>, B, C, Tuple2BoxT<T, C>>(curry(tuple2)(uv), f(snd(fa)), snd)(fb)
+        return compose<Tuple2BoxT<T, B>, B, C, Tuple2BoxT<T, C>>(curry(tuple2)(uv), f(snd(fa)), snd)(fst(fb), snd(fb))
     },
 })
 

--- a/src/ghc/base/tuple/tuple2-functor.ts
+++ b/src/ghc/base/tuple/tuple2-functor.ts
@@ -19,7 +19,7 @@ export interface Tuple2Functor<T> extends Functor {
 const fmap = <T>(): FunctorBase => ({
     // fmap :: Tuple2Box f => (a -> b) ->  f a -> f b
     fmap: <A, B>(f: (a: A) => NonNullable<B>, fa: Tuple2Box<T, A>): Tuple2Box<T, B> =>
-        compose<Tuple2Box<T, A>, A, B, Tuple2Box<T, B>>(curry(tuple2)(fst(fa)), f, snd)(fa),
+        compose<Tuple2Box<T, A>, A, B, Tuple2Box<T, B>>(curry(tuple2)(fst(fa)), f, snd)(fst(fa), snd(fa)),
 })
 
 export const functor = <T>() => createFunctor(fmap<T>()) as Tuple2Functor<T>


### PR DESCRIPTION
## Summary
- avoid spreading tuple arguments when composing tuple applicative and functor

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898597c87948328b80e386e3ea1ea3b