### PR TITLE
test: increase coverage

### DIFF
--- a/test/ghc/base/functions/basic.test.ts
+++ b/test/ghc/base/functions/basic.test.ts
@@ -1,0 +1,23 @@
+import tap from 'tap'
+import { $const, flip, dot, id } from 'ghc/base/functions'
+
+// Tests for basic helper functions
+
+// $const should ignore its second argument
+const three = $const(3)
+
+// flip should reverse argument order
+const subtract = (a: number, b: number) => a - b
+const flipped = flip(subtract)
+
+// dot should compose two functions
+const inc = (x: number) => x + 1
+const double = (x: number) => x * 2
+const composed = dot(double)(inc)
+
+tap.test('basic functions', async (t) => {
+    t.equal(id(4), 4)
+    t.equal(three('ignored'), 3)
+    t.equal(flipped(1, 5), 4)
+    t.equal(composed(3), 8)
+})

--- a/test/ghc/base/list/list.test.ts
+++ b/test/ghc/base/list/list.test.ts
@@ -201,8 +201,19 @@ tap.test('List', async (t) => {
     })
 
     t.test('kind', async (t) => {
-        const list = cons(1)(nil())
+        const empty = nil<number>()
+        const list = cons(1)(empty)
+        const mapped = map((x) => x, list)
+        const concatenated = concat(empty, list)
+        const taken = take(1, list)
+        const repeated = repeat(1)
 
         t.equal(kindOf(list), '*')
+        t.equal(empty.kind('*'), '*')
+        t.equal(list.kind('*'), '*')
+        t.equal(mapped.kind('*'), '*')
+        t.equal(concatenated.kind('*'), '*')
+        t.equal(taken.kind('*'), '*')
+        t.equal(repeated.kind('*'), '*')
     })
 })

--- a/test/ghc/base/maybe/maybe.test.ts
+++ b/test/ghc/base/maybe/maybe.test.ts
@@ -66,5 +66,7 @@ tap.test('Maybe', async (t) => {
 
         t.equal(kindOf(justValue), '*')
         t.equal(kindOf(nothingValue), '*')
+        t.equal(justValue.kind('*'), '*')
+        t.equal(nothingValue.kind('*'), '*')
     })
 })


### PR DESCRIPTION
## Summary
- add basic unit tests for helper functions ($const, flip, dot, id)
- assert `kind` on List and Maybe values for better coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68992f9c085c832886ebc854991764c0