### PR TITLE
Add tests for List take edge cases and concat kind

### DIFF
--- a/test/ghc/base/list/list.test.ts
+++ b/test/ghc/base/list/list.test.ts
@@ -192,6 +192,8 @@ tap.test('List', async (t) => {
         t.same(toArray(take(3, nill)), [])
         t.same(toArray(take(5, cons1)), [1])
         t.same(toArray(take(3, cons2)), [3, 2, 1])
+        t.same(toArray(take(0, cons2)), [])
+        t.same(toArray(take(-1, cons2)), [])
     })
 
     t.test('repeat', async (t) => {
@@ -205,6 +207,7 @@ tap.test('List', async (t) => {
         const list = cons<number>(1)(empty)
         const mapped = map((x) => x, list)
         const concatenated = concat(empty, list)
+        const concatenatedNonEmpty = concat(list, empty)
         const taken = take(1, list)
         const repeated = repeat<number>(1)
 
@@ -217,6 +220,7 @@ tap.test('List', async (t) => {
         t.equal(list.kind(star), '*')
         t.equal(mapped.kind(star), '*')
         t.equal(concatenated.kind(star), '*')
+        t.equal(concatenatedNonEmpty.kind(star), '*')
         t.equal(taken.kind(star), '*')
         t.equal(repeated.kind(star), '*')
     })


### PR DESCRIPTION
## Summary
- cover `take` with zero and negative counts
- verify `concat` results' `kind` to exercise `kind` function

## Testing
- `npm test`
- `npx c8 report --reporter=text --include=src/ghc/base/list/list.ts --temp-directory=.tap/coverage`


------
https://chatgpt.com/codex/tasks/task_e_689940150138832881a872d72988d251