### PR TITLE
Add tests for tuple helpers

### DIFF
--- a/test/ghc/base/tuple/tuple.test.ts
+++ b/test/ghc/base/tuple/tuple.test.ts
@@ -1,5 +1,5 @@
 import tap from 'tap'
-import { curry } from 'ghc/base/tuple/tuple'
+import { curry, fst, snd, tuple2, unit } from 'ghc/base/tuple/tuple'
 
 tap.test('curry', async (t) => {
     const add = (x: number, y: number): number => x + y
@@ -7,4 +7,29 @@ tap.test('curry', async (t) => {
 
     t.equal(curriedAdd(1)(2), 3)
     t.equal(add(1, 2), 3)
+})
+
+tap.test('fst and snd', async (t) => {
+    const tuple = tuple2(1, 'a')
+
+    t.equal(fst(tuple), 1)
+    t.equal(snd(tuple), 'a')
+
+    t.equal(fst([2, 'b']), 2)
+    t.equal(snd([2, 'b']), 'b')
+})
+
+tap.test('unit', async (t) => {
+    const u = unit()
+
+    t.same([...u], [])
+    t.equal(u.kind, '*')
+})
+
+tap.test('tuple2', async (t) => {
+    const t2 = tuple2(1, 'a')
+
+    t.equal(t2[0], 1)
+    t.equal(t2[1], 'a')
+    t.equal(t2.kind('*')('*'), '*')
 })


### PR DESCRIPTION
## Summary
- cover tuple utilities `fst`, `snd`, `unit`, and `tuple2`

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68999c89b414832888a79cb64899d2c9