### PR TITLE
Ensure NonEmpty list is fully covered

### DIFF
--- a/test/ghc/base/non-empty/non-empty.test.ts
+++ b/test/ghc/base/non-empty/non-empty.test.ts
@@ -11,6 +11,8 @@ import {
 } from 'ghc/base/list/list'
 import { $case, _, cons, formList, head, map, NonEmpty, nonEmpty, tail, toList } from 'ghc/base/non-empty/list'
 
+type KindFunc = Func & { kind: Func }
+
 tap.test('NonEmpty', async (t) => {
     t.test('nonEmpty', async (t) => {
         const value0 = compose(nonEmpty)(nil<number>())
@@ -29,6 +31,9 @@ tap.test('NonEmpty', async (t) => {
         t.equal(((value3() as Func)() as never[])[0], 1)
         t.equal(listHead(((value3() as Func)() as never[])[1] as unknown as List<number>), 2)
         t.equal(listHead(listTail(((value3() as Func)() as never[])[1] as unknown as List<number>)), 3)
+        t.equal(((value1() as KindFunc).kind('*')), '*')
+        t.equal(((value2() as KindFunc).kind('*')), '*')
+        t.equal(((value3() as KindFunc).kind('*')), '*')
     })
 
     t.test('cons', async (t) => {
@@ -42,6 +47,8 @@ tap.test('NonEmpty', async (t) => {
         t.equal(head(result2), 1)
         t.same(toArray(tail(result1)), [])
         t.same(toArray(tail(result2)), [2])
+        t.equal((result1 as KindFunc).kind('*'), '*')
+        t.equal((result2 as KindFunc).kind('*'), '*')
     })
 
     t.test('head', async (t) => {
@@ -72,6 +79,7 @@ tap.test('NonEmpty', async (t) => {
         t.equal(((result2 as Func)() as never[])[0], 2)
         t.equal(listHead(((result2 as Func)() as never[])[1] as unknown as List<number>), 3)
         t.ok($null(listTail(((result2 as Func)() as never[])[1] as unknown as List<number>)))
+        t.equal((result2 as KindFunc).kind('*'), '*')
     })
 
     t.test('toListList', async (t) => {
@@ -88,6 +96,7 @@ tap.test('NonEmpty', async (t) => {
         const result = map((x) => x + 1, list)
 
         t.same(toArray(toList(result)), [1, 2, 3, 4])
+        t.equal((result as KindFunc).kind('*'), '*')
     })
 
     t.test('$case', async (t) => {


### PR DESCRIPTION
## Summary
- cover `NonEmpty` list helpers' `.kind` property to reach 100% function coverage

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npx tap report text`


------
https://chatgpt.com/codex/tasks/task_e_6899a11d94e08328b29fb0a4bf4e11d4