### PR TITLE
feat: add reader type and semigroup

### DIFF
--- a/src/control/reader/reader.ts
+++ b/src/control/reader/reader.ts
@@ -1,0 +1,9 @@
+import { FunctionArrow, FunctionArrowBox, withKind } from 'ghc/prim/function-arrow'
+
+export type Reader<R, A> = FunctionArrow<R, A>
+
+export type ReaderBox<R, A> = FunctionArrowBox<R, A>
+
+export const reader = <R, A>(fn: Reader<R, A>): ReaderBox<R, A> => withKind(fn)
+
+export const runReader = <R, A>(fn: Reader<R, A>, r: R): A => fn(r)

--- a/src/control/reader/semigroup.ts
+++ b/src/control/reader/semigroup.ts
@@ -1,0 +1,8 @@
+import { Semigroup } from 'ghc/base/semigroup'
+import { semigroup as functionSemigroup } from 'ghc/base/function-arrow/semigroup'
+import { ReaderBox } from './reader'
+
+export type ReaderSemigroup<R, A> = Semigroup<ReaderBox<R, A>>
+
+export const semigroup = <R, A>(inner: Semigroup<A>): ReaderSemigroup<R, A> =>
+    functionSemigroup<R, A>(inner) as ReaderSemigroup<R, A>

--- a/test/control/reader/semigroup.test.ts
+++ b/test/control/reader/semigroup.test.ts
@@ -1,0 +1,61 @@
+import tap from 'tap'
+import { semigroup as createReaderSemigroup } from 'control/reader/semigroup'
+import { reader, ReaderBox } from 'control/reader/reader'
+import { semigroup as createListSemigroup, ListSemigroup } from 'ghc/base/list/semigroup'
+import { cons, ListBox, nil, toArray } from 'ghc/base/list/list'
+import { formList } from 'ghc/base/non-empty/list'
+
+const listSemigroup = createListSemigroup<number>()
+const semigroup = createReaderSemigroup<string, ListSemigroup<number>>(listSemigroup)
+
+const createValue = (separator: string): ReaderBox<string, ListBox<number>> =>
+    reader((x: string) =>
+        x
+            .split('')
+            .join(separator)
+            .split('')
+            .reduceRight((acc, curr) => cons(Number(curr))(acc), nil<number>()),
+    )
+
+tap.test('ReaderSemigroup', async (t) => {
+    t.test('<>', async (t) => {
+        const value1 = createValue('7')
+        const value2 = createValue('0')
+
+        const result = semigroup['<>'](value1, value2)
+        t.same(toArray(result('123') as ListBox<number>), [1, 7, 2, 7, 3, 1, 0, 2, 0, 3])
+    })
+
+    t.test('sconcat', async (t) => {
+        const value1 = createValue('1')
+        const value2 = createValue('2')
+        const value3 = createValue('3')
+        const value4 = cons(value3)(cons(value2)(cons(value1)(nil())))
+
+        const result = semigroup.sconcat(formList(value4))
+
+        t.same(toArray(result('56') as ListBox<number>), [5, 3, 6, 5, 2, 6, 5, 1, 6])
+    })
+
+    t.test('stimes', async (t) => {
+        const value1 = createValue('1')
+
+        const result = semigroup.stimes(3, value1)
+
+        t.same(toArray(result('00') as ListBox<number>), [0, 1, 0, 0, 1, 0, 0, 1, 0])
+    })
+
+    t.test('semigroup law - associativity: (x <> y) <> z = x <> (y <> z)', async (t) => {
+        const value1 = createValue('11')
+        const value2 = createValue('22')
+        const value3 = createValue('33')
+
+        const result1 = semigroup['<>'](semigroup['<>'](value1, value2), value3)
+        const result2 = semigroup['<>'](value1, semigroup['<>'](value2, value3))
+
+        const expected = [5, 1, 1, 6, 5, 2, 2, 6, 5, 3, 3, 6]
+
+        t.same(toArray(result1('56') as ListBox<number>), expected)
+        t.same(toArray(result2('56') as ListBox<number>), expected)
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
       "ghc/*": ["src/ghc/*"],
       "data/*": ["src/data/*"],
       "extra/*": ["src/extra/*"],
+      "control/*": ["src/control/*"],
     },                                                   /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */


### PR DESCRIPTION
## Summary
- implement Reader type as a thin alias over function arrows
- lift Semigroup over Reader via function arrow Semigroup
- test Reader Semigroup laws

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b889d7ec8328aa55342bfd0d5699