### PR TITLE
Add Reader functor and tests

### DIFF
--- a/src/control/reader/functor.ts
+++ b/src/control/reader/functor.ts
@@ -1,0 +1,24 @@
+import { Functor, FunctorBase, functor as createFunctor } from 'ghc/base/functor'
+import { reader, ReaderBox } from './reader'
+
+export interface ReaderFunctor<R> extends Functor {
+    fmap<A, B>(f: (a: A) => B, fa: ReaderBox<R, A>): ReaderBox<R, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: ReaderBox<R, A>): ReaderBox<R, B>
+
+    '<$'<A, B>(a: A, fb: ReaderBox<R, B>): ReaderBox<R, A>
+
+    '$>'<A, B>(fa: ReaderBox<R, A>, b: B): ReaderBox<R, B>
+
+    '<&>'<A, B>(fa: ReaderBox<R, A>, f: (a: A) => B): ReaderBox<R, B>
+
+    void<A>(fa: ReaderBox<R, A>): ReaderBox<R, []>
+}
+
+const fmap = <R>(): FunctorBase => ({
+    // fmap :: Reader r => (a -> b) -> Reader r a -> Reader r b
+    fmap: <A, B>(f: (a: A) => NonNullable<B>, fa: ReaderBox<R, A>): ReaderBox<R, B> =>
+        reader((r: R) => f(fa.runReader(r))),
+})
+
+export const functor = <R>() => createFunctor(fmap<R>()) as ReaderFunctor<R>

--- a/test/control/reader/functor.test.ts
+++ b/test/control/reader/functor.test.ts
@@ -1,0 +1,75 @@
+import tap from 'tap'
+import { compose, id } from 'ghc/base/functions'
+import { functor as createFunctor } from 'control/reader/functor'
+import { reader, ReaderBox } from 'control/reader/reader'
+
+const functor = createFunctor<string>()
+const lengthReader = reader((env: string) => env.length)
+
+// For using in laws tests maybe
+
+const fmapId = (fa: ReaderBox<string, number>) => functor.fmap(id, fa)
+
+// Compose functions for law 2: need to compose with compose from functions
+
+// But we define after in tests.
+
+tap.test('ReaderFunctor functor', async (t) => {
+    t.test('fmap', async (t) => {
+        const result = functor.fmap((x: number) => x + 1, lengthReader)
+        t.equal(result.runReader('abc'), 4)
+    })
+
+    t.test('<$>', async (t) => {
+        const result = functor['<$>']((x: number) => x * 2, lengthReader)
+        t.equal(result.runReader('abcd'), 8)
+    })
+
+    t.test('<$', async (t) => {
+        const result = functor['<$'](5, lengthReader)
+        t.equal(result.runReader('hello'), 5)
+    })
+
+    t.test('$>', async (t) => {
+        const result = functor['$>'](lengthReader, 7)
+        t.equal(result.runReader('world'), 7)
+    })
+
+    t.test('<&>', async (t) => {
+        const result = functor['<&>'](lengthReader, (x: number) => x + 2)
+        t.equal(result.runReader('abcd'), 6)
+    })
+
+    t.test('void', async (t) => {
+        const result = functor.void(lengthReader)
+        t.same(result.runReader('anything'), [])
+    })
+
+    t.test('Functor first law: fmap id = id', async (t) => {
+        const result = fmapId(lengthReader)
+        const expected = id(lengthReader)
+
+        const envs = ['test', 'abcd']
+        envs.forEach((env) => {
+            t.equal(result.runReader(env), expected.runReader(env))
+        })
+    })
+
+    t.test('Functor second law: fmap (f . g) = fmap f . fmap g', async (t) => {
+        const a = (x: number) => x + 2
+        const b = (x: number) => x * 3
+        const ab = compose(a, b)
+        const fA = (fa: ReaderBox<string, number>) => functor.fmap(a, fa)
+        const fB = (fb: ReaderBox<string, number>) => functor.fmap(b, fb)
+        const fAB = (fab: ReaderBox<string, number>) => functor.fmap(ab, fab)
+        const fAfB = compose(fA, fB)
+
+        const one = fAB(lengthReader)
+        const two = fAfB(lengthReader)
+
+        const envs = ['abcd', 'abcde']
+        envs.forEach((env) => {
+            t.equal(two.runReader(env), one.runReader(env))
+        })
+    })
+})


### PR DESCRIPTION
## Summary
- implement Reader functor with fmap and helper operations
- cover Reader functor with unit tests and functor law checks across environments

## Testing
- `npm run lint`
- `npm run build`
- `npx tap --node-arg=-r --node-arg=tsconfig-paths/register test/control/reader/*.test.ts`
- `npx tap report`


------
https://chatgpt.com/codex/tasks/task_e_689a978f4f548328a97d81b65c365b4b