### PR TITLE
Add Reader monad with comprehensive tests

### DIFF
--- a/src/control/reader/monad.ts
+++ b/src/control/reader/monad.ts
@@ -1,0 +1,47 @@
+import { Monad, monad as createMonad } from 'ghc/base/monad/monad'
+import { applicative as createApplicative } from './applicative'
+import { reader, ReaderBox } from './reader'
+import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+
+export interface ReaderMonad<R> extends Monad {
+    '>>='<A, B>(ma: ReaderBox<R, A>, f: FunctionArrow<A, ReaderBox<R, B>>): ReaderBox<R, B>
+
+    '>>'<A, B>(ma: ReaderBox<R, A>, mb: ReaderBox<R, B>): ReaderBox<R, B>
+
+    return<A>(a: NonNullable<A>): ReaderBox<R, A>
+
+    pure<A>(a: NonNullable<A>): ReaderBox<R, A>
+
+    '<*>'<A, B>(f: ReaderBox<R, FunctionArrow<A, B>>, fa: ReaderBox<R, A>): ReaderBox<R, B>
+
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, C>, fa: ReaderBox<R, A>, fb: ReaderBox<R, B>): ReaderBox<R, C>
+
+    '*>'<A, B>(fa: ReaderBox<R, A>, fb: ReaderBox<R, B>): ReaderBox<R, B>
+
+    '<*'<A, B>(fa: ReaderBox<R, A>, fb: ReaderBox<R, B>): ReaderBox<R, A>
+
+    '<**>'<A, B>(fa: ReaderBox<R, A>, f: ReaderBox<R, FunctionArrow<A, B>>): ReaderBox<R, B>
+
+    fmap<A, B>(f: (a: A) => B, fa: ReaderBox<R, A>): ReaderBox<R, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: ReaderBox<R, A>): ReaderBox<R, B>
+
+    '<$'<A, B>(a: A, fb: ReaderBox<R, B>): ReaderBox<R, A>
+
+    '$>'<A, B>(fa: ReaderBox<R, A>, b: B): ReaderBox<R, B>
+
+    '<&>'<A, B>(fa: ReaderBox<R, A>, f: (a: A) => B): ReaderBox<R, B>
+
+    void<A>(fa: ReaderBox<R, A>): ReaderBox<R, []>
+}
+
+const baseImplementation = <R>() => ({
+    '>>=': <A, B>(ma: ReaderBox<R, A>, f: FunctionArrow<A, ReaderBox<R, B>>): ReaderBox<R, B> =>
+        reader((r: R) => f(ma.runReader(r)).runReader(r)),
+})
+
+export const monad = <R>(): ReaderMonad<R> => {
+    const base = baseImplementation<R>()
+    const applicative = createApplicative<R>()
+    return createMonad(base, applicative) as ReaderMonad<R>
+}

--- a/test/control/reader/monad.test.ts
+++ b/test/control/reader/monad.test.ts
@@ -1,0 +1,82 @@
+import tap from 'tap'
+import { monad as createMonad } from 'control/reader/monad'
+import { reader, ReaderBox } from 'control/reader/reader'
+import { doNotation } from 'ghc/base/monad/do-notation'
+
+const monad = createMonad<string>()
+
+const run = <A>(r: ReaderBox<string, A>, env: string) => r.runReader(env)
+
+tap.test('Reader monad', async (t) => {
+    t.test('return', async (t) => {
+        const result = monad.pure(3)
+
+        t.equal(run(result, 'env'), 3)
+    })
+
+    t.test('>>=', async (t) => {
+        const value = reader((env: string) => env.length)
+        const f = (x: number) => reader((env: string) => x + env.length)
+
+        const result = monad['>>='](value, f)
+
+        t.equal(run(result, 'abcd'), 8)
+    })
+
+    t.test('>>', async (t) => {
+        const value1 = reader((env: string) => env.length)
+        const value2 = reader((env: string) => env.toUpperCase())
+
+        const result = monad['>>'](value1, value2)
+
+        t.equal(run(result, 'abc'), 'ABC')
+    })
+
+    t.test('Monad first law (Left identity): return a >>= h = h a', async (t) => {
+        const a = 5
+        const returnA = monad.return(a)
+        const h = (x: number) => reader((env: string) => x + env.length)
+
+        const left = monad['>>='](returnA, h)
+        const right = h(a)
+
+        t.equal(run(left, 'abcd'), run(right, 'abcd'))
+        t.equal(run(right, 'abcd'), 9)
+    })
+
+    t.test('Monad second law (Right identity): m >>= return = m', async (t) => {
+        const m = reader((env: string) => env.length)
+        const left = monad['>>='](m, monad.return)
+
+        t.equal(run(left, 'abcd'), run(m, 'abcd'))
+        t.equal(run(left, 'abcd'), 4)
+    })
+
+    t.test('Monad thrird law (Associativity): (m >>= g) >>= h = m >>= (x -> g x >>= h)', async (t) => {
+        const m = reader((env: string) => env.length)
+        const g = (x: number) => reader((env: string) => x + env.length)
+        const h = (x: number) => reader((env: string) => x * 2)
+
+        const left = monad['>>='](monad['>>='](m, g), h)
+        const right = monad['>>='](m, (x: number) => monad['>>='](g(x), h))
+
+        t.equal(run(left, 'abc'), run(right, 'abc'))
+        t.equal(run(left, 'abc'), 12)
+    })
+
+    t.test('do-notation', async (t) => {
+        const result = doNotation<ReaderBox<string, number>>(function* (): Generator<
+            ReaderBox<string, number>,
+            number,
+            number
+        > {
+            const value1 = (yield reader((env: string) => env.length)) as number
+            const value2 = (yield reader((env: string) => env.length * 2)) as number
+            return value1 + value2
+        },
+        monad)
+
+        t.equal(run(result, 'abcd'), 12)
+    })
+})
+


### PR DESCRIPTION
## Summary
- implement Reader monad with bind operation and integration with existing applicative
- add tests covering Reader monad operations, laws, and do-notation

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npx tap report text`


------
https://chatgpt.com/codex/tasks/task_e_689acf51ec788328ab372690138fc916