### PR TITLE
Refactor crossJoinList to recursive generator

### DIFF
--- a/src/ghc/base/list/comprehension.ts
+++ b/src/ghc/base/list/comprehension.ts
@@ -1,58 +1,25 @@
 import { Type } from 'data/kind'
-import { List, ListBox, $null, head, tail, cons, nil } from './list'
+import { List, ListBox, $null, head, tail, nil } from './list'
 
 function* crossJoinList<T>(...lists: List<T>[]) {
-    if (lists.length <= 0) {
+    if (lists.length === 0) {
         yield []
         return
     }
 
-    if (lists.length <= 1) {
-        let list = lists[0]
-        while (list && !$null(list)) {
-            const headValue = head(list)
-            yield [headValue]
-            list = tail(list)
-        }
-        return
-    }
+    let list = lists[0]
+    const rest = lists.slice(1)
 
-    let result = lists[0] as List<T[]>
-    for (let i = 1; i < lists.length; i++) {
-        const fmap: T[][] = []
-        let tempResult = result
+    while (list && !$null(list)) {
+        const headValue = head(list)
 
-        while (tempResult && !$null(tempResult)) {
-            const tempResultHead = head(tempResult)
-            const map: T[][] = []
-
-            let current = lists[i]
-            while (current && !$null(current)) {
-                const currentHead = head(current)
-                const result = [tempResultHead, currentHead].flat() as T[]
-
-                if (result.length === lists.length) {
-                    yield result
-                }
-
-                map.push(result)
-
-                current = tail(current)
+        yield* (function* () {
+            for (const tailValues of crossJoinList<T>(...rest)) {
+                yield [headValue, ...tailValues]
             }
+        })()
 
-            fmap.push(...map)
-
-            tempResult = tail(tempResult)
-        }
-
-        if (i !== lists.length - 1) {
-            let resultTail = nil<T[]>()
-            for (let j = fmap.length - 1; j >= 0; j--) {
-                resultTail = cons(fmap[j] as T[])(resultTail)
-            }
-
-            result = resultTail
-        }
+        list = tail(list)
     }
 }
 


### PR DESCRIPTION
## Summary
- simplify crossJoinList by using recursion and a while loop
- remove temporary array handling and result rebuilding

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689adbd033708328a1d85f0e43349d0b