### PR TITLE
Add ask, asks, and local helpers to Reader monad

### DIFF
--- a/src/control/reader/reader.ts
+++ b/src/control/reader/reader.ts
@@ -14,3 +14,10 @@ export const reader = <R, A>(fn: (r: R) => A): ReaderBox<R, A> => ({
 })
 
 export const runReader = <R, A>(ra: Reader<R, A>, r: R): A => ra.runReader(r)
+
+export const ask = <R>(): ReaderBox<R, R> => reader((r: R) => r)
+
+export const asks = <R, A>(f: (r: R) => A): ReaderBox<R, A> => reader((r: R) => f(r))
+
+export const local = <R, A>(f: (r: R) => R, ma: ReaderBox<R, A>): ReaderBox<R, A> =>
+    reader((r: R) => ma.runReader(f(r)))

--- a/test/control/reader/reader.test.ts
+++ b/test/control/reader/reader.test.ts
@@ -1,5 +1,5 @@
 import tap from 'tap'
-import { reader, runReader } from 'control/reader/reader'
+import { reader, runReader, ask, asks, local } from 'control/reader/reader'
 
 tap.test('reader and runReader', async (t) => {
     const run = reader((env: string) => env.length)
@@ -7,4 +7,19 @@ tap.test('reader and runReader', async (t) => {
     t.equal(run.runReader('hello'), 5)
     t.equal(runReader(run, 'world'), 5)
     t.equal(run.kind('*')('*'), '*')
+})
+
+tap.test('ask returns the current environment', async (t) => {
+    t.same(ask<string>().runReader('hi'), 'hi')
+})
+
+tap.test('asks maps the environment', async (t) => {
+    const getLength = asks((env: string) => env.length)
+    t.equal(getLength.runReader('hello'), 5)
+})
+
+tap.test('local runs a Reader under a modified environment', async (t) => {
+    const computation = asks((env: string) => env.length)
+    const modified = local((env: string) => `${env}!`, computation)
+    t.equal(modified.runReader('hi'), 3)
 })


### PR DESCRIPTION
## Summary
- add `ask`, `asks`, and `local` helpers to Reader module
- test Reader helpers `ask`, `asks`, and `local`

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd82fec2883288a309367528f129b