### PR TITLE
Add mapReader and withReader to Reader

### DIFF
--- a/src/control/reader/reader.ts
+++ b/src/control/reader/reader.ts
@@ -15,6 +15,12 @@ export const reader = <R, A>(fn: (r: R) => A): ReaderBox<R, A> => ({
 
 export const runReader = <R, A>(ra: Reader<R, A>, r: R): A => ra.runReader(r)
 
+export const mapReader = <R, A, B>(f: (a: A) => B, ra: ReaderBox<R, A>): ReaderBox<R, B> =>
+    reader((r: R) => f(ra.runReader(r)))
+
+export const withReader = <R, RPrime, A>(f: (r: RPrime) => R, ra: ReaderBox<R, A>): ReaderBox<RPrime, A> =>
+    reader((r: RPrime) => ra.runReader(f(r)))
+
 export const ask = <R>(): ReaderBox<R, R> => reader((r: R) => r)
 
 export const asks = <R, A>(f: (r: R) => A): ReaderBox<R, A> => reader((r: R) => f(r))

--- a/test/control/reader/reader.test.ts
+++ b/test/control/reader/reader.test.ts
@@ -1,5 +1,5 @@
 import tap from 'tap'
-import { reader, runReader, ask, asks, local } from 'control/reader/reader'
+import { reader, runReader, ask, asks, local, mapReader, withReader } from 'control/reader/reader'
 
 tap.test('reader and runReader', async (t) => {
     const run = reader((env: string) => env.length)
@@ -22,4 +22,16 @@ tap.test('local runs a Reader under a modified environment', async (t) => {
     const computation = asks((env: string) => env.length)
     const modified = local((env: string) => `${env}!`, computation)
     t.equal(modified.runReader('hi'), 3)
+})
+
+tap.test('mapReader maps the result of a Reader', async (t) => {
+    const computation = asks((env: string) => env.length)
+    const mapped = mapReader((n: number) => n * 2, computation)
+    t.equal(mapped.runReader('hey'), 6)
+})
+
+tap.test('withReader transforms the environment', async (t) => {
+    const computation = asks((env: string) => env.length)
+    const modified = withReader((n: number) => 'a'.repeat(n), computation)
+    t.equal(modified.runReader(4), 4)
 })


### PR DESCRIPTION
## Summary
- extend Reader with mapReader and withReader helpers
- test Reader mapping and environment transformation

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be7c61f0083288a4b97667554406a