### PR TITLE
Add Writer type with basic operations

### DIFF
--- a/src/control/writer/writer.ts
+++ b/src/control/writer/writer.ts
@@ -1,0 +1,24 @@
+import { Box2, MinBox0, Type } from 'data/kind'
+import { Tuple2Box } from 'ghc/base/tuple/tuple'
+
+export interface Writer<W, A> {
+    readonly runWriter: () => Tuple2Box<A, W>
+}
+
+export type WriterBox<W, A> = Writer<W, A> & Box2<W, A>
+
+export type WriterMinBox<W, A> = Writer<W, MinBox0<A>> & Box2<W, MinBox0<A>>
+
+export const writer = <W, A>(fn: () => Tuple2Box<A, W>): WriterBox<W, A> => ({
+    runWriter: fn,
+    kind: (_: '*') => (_: '*') => '*' as Type,
+})
+
+export const runWriter = <W, A>(wa: Writer<W, A>): Tuple2Box<A, W> => wa.runWriter()
+
+export const execWriter = <W, A>(wa: Writer<W, A>): W => wa.runWriter()[1]
+
+export const mapWriter = <W, A, WPrime, B>(
+    f: (aw: Tuple2Box<A, W>) => Tuple2Box<B, WPrime>,
+    wa: WriterBox<W, A>,
+): WriterBox<WPrime, B> => writer(() => f(wa.runWriter()))

--- a/test/control/writer/writer.test.ts
+++ b/test/control/writer/writer.test.ts
@@ -1,0 +1,25 @@
+import tap from 'tap'
+import { writer, runWriter, execWriter, mapWriter, WriterBox } from 'control/writer/writer'
+import { fst, snd, tuple2 } from 'ghc/base/tuple/tuple'
+
+tap.test('writer and runWriter', async (t) => {
+    const computation: WriterBox<string, number> = writer(() => tuple2(3, 'log'))
+
+    const result = runWriter(computation)
+    t.equal(fst(result), 3)
+    t.equal(snd(result), 'log')
+    t.equal(computation.kind('*')('*'), '*')
+})
+
+tap.test('execWriter extracts the written value', async (t) => {
+    const computation = writer(() => tuple2(5, 'log'))
+    t.equal(execWriter(computation), 'log')
+})
+
+tap.test('mapWriter maps the tuple result', async (t) => {
+    const computation = writer(() => tuple2(2, 'log'))
+    const mapped = mapWriter(([n, w]) => tuple2(n * 3, w + '!'), computation)
+    const tuple = runWriter(mapped)
+    t.equal(fst(tuple), 6)
+    t.equal(snd(tuple), 'log!')
+})


### PR DESCRIPTION
## Summary
- implement `Writer` type with `runWriter`, `execWriter`, and `mapWriter`
- test Writer behaviors including running, extracting, and mapping

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6a29904c8328a1756ba2a75af08d