### PR TITLE
docs: document typeclass hierarchy and instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,64 @@ npm run lint
 npm run build
 npm test
 ```
+
+## Typeclass relationships
+
+```
++-----------+          +-----------+
+| Semigroup | ───────► |  Monoid   |
++-----------+          +-----------+
+                          : \
+                          :  \............................ (Applicative as a monoidal pattern)
+                          :   \
+        +----------+      :    v
+        | Functor  | ─────► +-------------+
+        +----------+        | Applicative |
+              |             +-------------+
+              v                  |
+        +-------------+          v
+        | Applicative | ───────► +------+
+        +-------------+          | Monad|
+                                 +------+
+                                   ^
+                                   :
+                                   :............................ (Monad as a monoid
+ in endofunctors)
+```
+
+## Instances
+
+`✓` = available instance  
+`*` = requires the underlying value type to have the same instance
+
+```
+Type        Functor Applicative Monad Semigroup Monoid
+------------------------------------------------------
+Maybe          ✓        ✓         ✓        ✓*     ✓*
+Either e       ✓        ✓         ✓        ✓*     ✓*
+List           ✓        ✓         ✓        ✓      ✓
+NonEmpty       ✓        ✓         ✓        ✓      -
+Reader r       ✓        ✓         ✓        ✓*     ✓*
+Writer w       ✓        ✓         ✓        ✓*     ✓*
+(->) r         ✓        ✓         ✓        ✓*     ✓*
+Tuple2 a       ✓        ✓         ✓        ✓*     ✓*
+Promise        ✓        ✓         ✓        ✓*     ✓*
+Unit ()        -        -         -        ✓      ✓
+```
+
+## References
+
+- Functor
+- Applicative
+- Monad
+- Semigroup
+- Monoid
+- Maybe
+- Either
+- List
+- NonEmpty list
+- Reader
+- Writer
+- Function arrow `(->)`
+- Tuple2 and Unit
+- Promise


### PR DESCRIPTION
## Summary
- document typeclass relationships with ASCII diagram
- list instances for common types and reference sections in README
- refine diagram to show dotted relationships between monoid, applicative, and monad

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a047f990d083288eaf24ad155fe8d5