### PR TITLE
Add comonad helper combinators

### DIFF
--- a/src/control/comonad-apply.ts
+++ b/src/control/comonad-apply.ts
@@ -6,6 +6,7 @@ import { Comonad } from './comonad'
 export type ComonadApplyBase = Comonad & {
     '<@>'<A, B>(f: MinBox1<FunctionArrow<A, B>>, wa: MinBox1<A>): MinBox1<B>
     liftW2<A, B, C>(f: FunctionArrow2<A, B, C>, wa: MinBox1<A>, wb: MinBox1<B>): MinBox1<C>
+    kfix<A>(w: MinBox1<(wa: MinBox1<A>) => A>): MinBox1<A>
 }
 
 export type ComonadApply = ComonadApplyBase
@@ -24,6 +25,13 @@ export const comonadApply = (base: BaseImplementation, comonad: Comonad): Comona
     if (!result['<@>'] && result.liftW2) {
         result['<@>'] = <A, B>(wf: MinBox1<FunctionArrow<A, B>>, wa: MinBox1<A>): MinBox1<B> =>
             result.liftW2!(id, wf, wa)
+    }
+
+    result.kfix = <A>(w: MinBox1<(wa: MinBox1<A>) => A>): MinBox1<A> => {
+        let u!: MinBox1<A>
+        // eslint-disable-next-line prefer-const
+        u = result['<@>']!(w, result.duplicate(u as MinBox1<A>))
+        return u
     }
 
     return result

--- a/src/control/comonad.ts
+++ b/src/control/comonad.ts
@@ -10,6 +10,27 @@ export type ComonadBase = Functor & {
 
     // duplicate :: w a -> w (w a)
     duplicate?<A>(wa: MinBox1<A>): MinBox1<MinBox1<A>>
+
+    // liftW :: Comonad w => (a -> b) -> w a -> w b
+    liftW<A, B>(f: (a: A) => B, wa: MinBox1<A>): MinBox1<B>
+
+    // wfix :: Comonad w => w (w a -> a) -> a
+    wfix<A>(w: MinBox1<(wa: MinBox1<A>) => A>): A
+
+    // cfix :: Comonad w => (w a -> a) -> w a
+    cfix<A>(f: (wa: MinBox1<A>) => A): MinBox1<A>
+
+    // '=>>' :: Comonad w => w a -> (w a -> b) -> w b
+    '=>>'<A, B>(wa: MinBox1<A>, f: (wa: MinBox1<A>) => B): MinBox1<B>
+
+    // '<<=' :: Comonad w => (w a -> b) -> w a -> w b
+    '<<='<A, B>(f: (wa: MinBox1<A>) => B, wa: MinBox1<A>): MinBox1<B>
+
+    // '=<=' :: Comonad w => (w b -> c) -> (w a -> b) -> w a -> c
+    '=<='<A, B, C>(f: (wb: MinBox1<B>) => C, g: (wa: MinBox1<A>) => B, wa: MinBox1<A>): C
+
+    // '=>=' :: Comonad w => (w a -> b) -> (w b -> c) -> w a -> c
+    '=>='<A, B, C>(f: (wa: MinBox1<A>) => B, g: (wb: MinBox1<B>) => C, wa: MinBox1<A>): C
 }
 
 export type Comonad = ComonadBase & {
@@ -32,6 +53,29 @@ export const comonad = (base: BaseImplementation, functor: Functor): Comonad => 
     if (!result.duplicate && result.extend) {
         result.duplicate = <A>(wa: MinBox1<A>): MinBox1<MinBox1<A>> => result.extend!((w: MinBox1<A>) => w, wa)
     }
+
+    result.liftW = <A, B>(f: (a: A) => B, wa: MinBox1<A>): MinBox1<B> =>
+        result.extend((w: MinBox1<A>) => f(result.extract(w)), wa)
+
+    const wfix = <A>(w: MinBox1<(wa: MinBox1<A>) => A>): A => result.extract(w)(result.extend(wfix, w))
+    result.wfix = wfix
+
+    result.cfix = <A>(f: (wa: MinBox1<A>) => A): MinBox1<A> => {
+        let wa!: MinBox1<A>
+        // eslint-disable-next-line prefer-const
+        wa = result.extend(f, wa as MinBox1<A>)
+        return wa
+    }
+
+    result['=>>'] = <A, B>(wa: MinBox1<A>, f: (wa: MinBox1<A>) => B): MinBox1<B> => result.extend(f, wa)
+
+    result['<<='] = <A, B>(f: (wa: MinBox1<A>) => B, wa: MinBox1<A>): MinBox1<B> => result.extend(f, wa)
+
+    result['=<='] = <A, B, C>(f: (wb: MinBox1<B>) => C, g: (wa: MinBox1<A>) => B, wa: MinBox1<A>): C =>
+        f(result.extend(g, wa))
+
+    result['=>='] = <A, B, C>(f: (wa: MinBox1<A>) => B, g: (wb: MinBox1<B>) => C, wa: MinBox1<A>): C =>
+        g(result.extend(f, wa))
 
     return result
 }

--- a/test/control/reader/comonad-apply.test.ts
+++ b/test/control/reader/comonad-apply.test.ts
@@ -35,4 +35,11 @@ tap.test('Reader ComonadApply', async (t) => {
         const right = ca.liftW2((f: (a: number) => number) => (a: number) => f(a), wf, wa)
         t.equal(ca.extract(left), ca.extract(right))
     })
+
+    t.test('kfix', async (t) => {
+        const w = reader((_: void) => (_: unknown) => 5)
+        const result = ca.kfix(w as any)
+        const verify = ca['<@>'](w as any, ca.duplicate(result as any) as any)
+        t.equal(ca.extract(result as any), ca.extract(verify as any))
+    })
 })

--- a/test/control/reader/comonad.test.ts
+++ b/test/control/reader/comonad.test.ts
@@ -31,4 +31,52 @@ tap.test('Reader Comonad', async (t) => {
         const viaDuplicate = cm.fmap(f, cm.duplicate(ra))
         t.equal(cm.extract(viaExtend), cm.extract(viaDuplicate))
     })
+
+    t.test('liftW', async (t) => {
+        const f = (x: number) => x + 1
+        const viaLiftW = cm.liftW(f, ra) as any
+        const viaExtend = cm.extend((w) => f(cm.extract(w)), ra)
+        t.equal(cm.extract(viaLiftW as any), cm.extract(viaExtend))
+    })
+
+    t.test('(=>>)', async (t) => {
+        const f = (r: typeof ra) => cm.extract(r) + 1
+        const left = cm['=>>'](ra, f as any)
+        const right = cm.extend(f as any, ra)
+        t.equal(cm.extract(left as any), cm.extract(right as any))
+    })
+
+    t.test('(<<=)', async (t) => {
+        const f = (r: typeof ra) => cm.extract(r) + 1
+        const left = cm['<<='](f as any, ra)
+        const right = cm.extend(f as any, ra)
+        t.equal(cm.extract(left as any), cm.extract(right as any))
+    })
+
+    t.test('(=<=)', async (t) => {
+        const f = (w: typeof ra) => cm.extract(w) + 1
+        const g = (w: typeof ra) => cm.extract(w) * 2
+        const left = cm['=<='](f as any, g as any, ra)
+        const right = (f as any)(cm.extend(g as any, ra))
+        t.equal(left, right)
+    })
+
+    t.test('(=>=)', async (t) => {
+        const f = (w: typeof ra) => cm.extract(w) + 1
+        const g = (w: typeof ra) => cm.extract(w) * 2
+        const left = cm['=>='](f as any, g as any, ra)
+        const right = (g as any)(cm.extend(f as any, ra))
+        t.equal(left, right)
+    })
+
+    t.test('wfix', async (t) => {
+        const w = reader((_: void) => (_: typeof ra) => 5)
+        t.equal(cm.wfix(w as any), 5)
+    })
+
+    t.test('cfix', async (t) => {
+        const f = (_: typeof ra) => 7
+        const result = cm.cfix(f as any)
+        t.equal(cm.extract(result as any), 7)
+    })
 })


### PR DESCRIPTION
## Summary
- add liftW, wfix, cfix and Cokleisli operator helpers to Comonad
- add kfix for ComonadApply instances
- cover new combinators with Reader-based tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f12165a88328b6eb6af3e60348b9