### PR TITLE
Add flipped apply and ternary lift to ComonadApply

### DIFF
--- a/src/control/comonad-apply.ts
+++ b/src/control/comonad-apply.ts
@@ -1,11 +1,13 @@
 import { MinBox1 } from 'data/kind'
-import { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import { FunctionArrow, FunctionArrow2, FunctionArrow3 } from 'ghc/prim/function-arrow'
 import { id } from 'ghc/base/functions'
 import { Comonad } from './comonad'
 
 export type ComonadApplyBase = Comonad & {
     '<@>'<A, B>(f: MinBox1<FunctionArrow<A, B>>, wa: MinBox1<A>): MinBox1<B>
+    '<@@>'<A, B>(wa: MinBox1<A>, wf: MinBox1<FunctionArrow<A, B>>): MinBox1<B>
     liftW2<A, B, C>(f: FunctionArrow2<A, B, C>, wa: MinBox1<A>, wb: MinBox1<B>): MinBox1<C>
+    liftW3<A, B, C, D>(f: FunctionArrow3<A, B, C, D>, wa: MinBox1<A>, wb: MinBox1<B>, wc: MinBox1<C>): MinBox1<D>
     kfix<A>(w: MinBox1<(wa: MinBox1<A>) => A>): MinBox1<A>
 }
 
@@ -25,6 +27,20 @@ export const comonadApply = (base: BaseImplementation, comonad: Comonad): Comona
     if (!result['<@>'] && result.liftW2) {
         result['<@>'] = <A, B>(wf: MinBox1<FunctionArrow<A, B>>, wa: MinBox1<A>): MinBox1<B> =>
             result.liftW2!(id, wf, wa)
+    }
+
+    if (!result['<@@>']) {
+        result['<@@>'] = <A, B>(wa: MinBox1<A>, wf: MinBox1<FunctionArrow<A, B>>): MinBox1<B> =>
+            result.liftW2!((a: A) => (f: FunctionArrow<A, B>) => f(a), wa, wf)
+    }
+
+    if (!result.liftW3) {
+        result.liftW3 = <A, B, C, D>(
+            f: FunctionArrow3<A, B, C, D>,
+            wa: MinBox1<A>,
+            wb: MinBox1<B>,
+            wc: MinBox1<C>,
+        ): MinBox1<D> => result['<@>']!(result['<@>']!(comonad['<$>'](f, wa), wb), wc)
     }
 
     result.kfix = <A>(w: MinBox1<(wa: MinBox1<A>) => A>): MinBox1<A> => {

--- a/src/control/reader/comonad-apply.ts
+++ b/src/control/reader/comonad-apply.ts
@@ -1,11 +1,18 @@
 import { comonadApply as createComonadApply, ComonadApply, BaseImplementation } from 'control/comonad-apply'
 import { ReaderBox, reader } from './reader'
 import { comonad as createComonad } from './comonad'
-import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import type { FunctionArrow, FunctionArrow2, FunctionArrow3 } from 'ghc/prim/function-arrow'
 
 export interface ReaderComonadApply<R> extends ComonadApply {
     '<@>'<A, B>(f: ReaderBox<R, FunctionArrow<A, B>>, wa: ReaderBox<R, A>): ReaderBox<R, B>
+    '<@@>'<A, B>(wa: ReaderBox<R, A>, wf: ReaderBox<R, FunctionArrow<A, B>>): ReaderBox<R, B>
     liftW2<A, B, C>(f: FunctionArrow2<A, B, C>, wa: ReaderBox<R, A>, wb: ReaderBox<R, B>): ReaderBox<R, C>
+    liftW3<A, B, C, D>(
+        f: FunctionArrow3<A, B, C, D>,
+        wa: ReaderBox<R, A>,
+        wb: ReaderBox<R, B>,
+        wc: ReaderBox<R, C>,
+    ): ReaderBox<R, D>
 
     extract<A>(wa: ReaderBox<R, A>): A
     extend<A, B>(f: (wa: ReaderBox<R, A>) => B, wa: ReaderBox<R, A>): ReaderBox<R, B>

--- a/src/control/writer/comonad-apply.ts
+++ b/src/control/writer/comonad-apply.ts
@@ -1,12 +1,19 @@
 import { comonadApply as createComonadApply, ComonadApply, BaseImplementation } from 'control/comonad-apply'
 import { WriterBox, writer } from './writer'
 import { comonad as createComonad } from './comonad'
-import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import type { FunctionArrow, FunctionArrow2, FunctionArrow3 } from 'ghc/prim/function-arrow'
 import { Tuple2Box, tuple2 } from 'ghc/base/tuple/tuple'
 
 export interface WriterComonadApply<W> extends ComonadApply {
     '<@>'<A, B>(f: WriterBox<W, FunctionArrow<A, B>>, wa: WriterBox<W, A>): WriterBox<W, B>
+    '<@@>'<A, B>(wa: WriterBox<W, A>, wf: WriterBox<W, FunctionArrow<A, B>>): WriterBox<W, B>
     liftW2<A, B, C>(f: FunctionArrow2<A, B, C>, wa: WriterBox<W, A>, wb: WriterBox<W, B>): WriterBox<W, C>
+    liftW3<A, B, C, D>(
+        f: FunctionArrow3<A, B, C, D>,
+        wa: WriterBox<W, A>,
+        wb: WriterBox<W, B>,
+        wc: WriterBox<W, C>,
+    ): WriterBox<W, D>
 
     extract<A>(wa: WriterBox<W, A>): A
     extend<A, B>(f: (wa: WriterBox<W, A>) => B, wa: WriterBox<W, A>): WriterBox<W, B>

--- a/src/ghc/base/non-empty/comonad-apply.ts
+++ b/src/ghc/base/non-empty/comonad-apply.ts
@@ -1,12 +1,19 @@
 import { comonadApply as createComonadApply, ComonadApply, BaseImplementation } from 'control/comonad-apply'
 import { NonEmptyBox, head, tail, cons } from './list'
 import { comonad } from './comonad'
-import { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import { FunctionArrow, FunctionArrow2, FunctionArrow3 } from 'ghc/prim/function-arrow'
 import { ListBox, cons as listCons, head as listHead, tail as listTail, $null, nil } from 'ghc/base/list/list'
 
 export interface NonEmptyComonadApply extends ComonadApply {
     '<@>'<A, B>(f: NonEmptyBox<FunctionArrow<A, B>>, wa: NonEmptyBox<A>): NonEmptyBox<B>
+    '<@@>'<A, B>(wa: NonEmptyBox<A>, wf: NonEmptyBox<FunctionArrow<A, B>>): NonEmptyBox<B>
     liftW2<A, B, C>(f: FunctionArrow2<A, B, C>, wa: NonEmptyBox<A>, wb: NonEmptyBox<B>): NonEmptyBox<C>
+    liftW3<A, B, C, D>(
+        f: FunctionArrow3<A, B, C, D>,
+        wa: NonEmptyBox<A>,
+        wb: NonEmptyBox<B>,
+        wc: NonEmptyBox<C>,
+    ): NonEmptyBox<D>
 
     extract<A>(wa: NonEmptyBox<A>): A
     extend<A, B>(f: (wa: NonEmptyBox<A>) => NonNullable<B>, wa: NonEmptyBox<A>): NonEmptyBox<B>

--- a/src/ghc/base/tuple/tuple2-comonad-apply.ts
+++ b/src/ghc/base/tuple/tuple2-comonad-apply.ts
@@ -1,11 +1,18 @@
 import { comonadApply as createComonadApply, ComonadApply, BaseImplementation } from 'control/comonad-apply'
 import { Tuple2BoxT, tuple2 } from './tuple'
 import { comonad as createComonad } from './tuple2-comonad'
-import { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import { FunctionArrow, FunctionArrow2, FunctionArrow3 } from 'ghc/prim/function-arrow'
 
 export interface Tuple2ComonadApply<T> extends ComonadApply {
     '<@>'<A, B>(f: Tuple2BoxT<T, FunctionArrow<A, B>>, wa: Tuple2BoxT<T, A>): Tuple2BoxT<T, B>
+    '<@@>'<A, B>(wa: Tuple2BoxT<T, A>, wf: Tuple2BoxT<T, FunctionArrow<A, B>>): Tuple2BoxT<T, B>
     liftW2<A, B, C>(f: FunctionArrow2<A, B, C>, wa: Tuple2BoxT<T, A>, wb: Tuple2BoxT<T, B>): Tuple2BoxT<T, C>
+    liftW3<A, B, C, D>(
+        f: FunctionArrow3<A, B, C, D>,
+        wa: Tuple2BoxT<T, A>,
+        wb: Tuple2BoxT<T, B>,
+        wc: Tuple2BoxT<T, C>,
+    ): Tuple2BoxT<T, D>
 
     extract<A>(wa: Tuple2BoxT<T, A>): A
     extend<A, B>(f: (wa: Tuple2BoxT<T, A>) => B, wa: Tuple2BoxT<T, A>): Tuple2BoxT<T, B>

--- a/src/ghc/prim/function-arrow/index.ts
+++ b/src/ghc/prim/function-arrow/index.ts
@@ -4,6 +4,8 @@ export type FunctionArrow<A, B> = (_: A) => B
 
 export type FunctionArrow2<A, B, C> = (_: A) => (_: B) => C
 
+export type FunctionArrow3<A, B, C, D> = (_: A) => (_: B) => (_: C) => D
+
 export type FunctionArrowBox<A, B> = FunctionArrow<A, B> & Box2<A, B>
 
 export const withKind = <A, B>(base: FunctionArrow<A, B>): FunctionArrowBox<A, B> => base as FunctionArrowBox<A, B>

--- a/test/control/reader/comonad-apply.test.ts
+++ b/test/control/reader/comonad-apply.test.ts
@@ -12,11 +12,31 @@ tap.test('Reader ComonadApply', async (t) => {
         t.equal(ca.extract(result), 2)
     })
 
+    t.test('<@@>', async (t) => {
+        const wa = reader((_: void) => 1)
+        const wf = reader((_: void) => (x: number) => x + 1)
+        const result = ca['<@@>'](wa, wf)
+        t.equal(ca.extract(result), 2)
+    })
+
     t.test('liftW2', async (t) => {
         const wa = reader((_: void) => 1)
         const wb = reader((_: void) => 2)
         const result = ca.liftW2((a: number) => (b: number) => a + b, wa, wb)
         t.equal(ca.extract(result), 3)
+    })
+
+    t.test('liftW3', async (t) => {
+        const wa = reader((_: void) => 1)
+        const wb = reader((_: void) => 2)
+        const wc = reader((_: void) => 3)
+        const result = ca.liftW3(
+            (a: number) => (b: number) => (c: number) => a + b + c,
+            wa,
+            wb,
+            wc,
+        )
+        t.equal(ca.extract(result), 6)
     })
 
     t.test('liftW2 f a b = f <$> a <@> b', async (t) => {
@@ -25,6 +45,16 @@ tap.test('Reader ComonadApply', async (t) => {
         const b = reader((_: void) => 2)
         const left = ca.liftW2(f, a, b)
         const right = ca['<@>'](ca['<$>'](f, a), b)
+        t.equal(ca.extract(left), ca.extract(right))
+    })
+
+    t.test('liftW3 f a b c = f <$> a <@> b <@> c', async (t) => {
+        const f = (x: number) => (y: number) => (z: number) => x + y + z
+        const a = reader((_: void) => 1)
+        const b = reader((_: void) => 2)
+        const c = reader((_: void) => 3)
+        const left = ca.liftW3(f, a, b, c)
+        const right = ca['<@>'](ca['<@>'](ca['<$>'](f, a), b), c)
         t.equal(ca.extract(left), ca.extract(right))
     })
 

--- a/test/control/writer/comonad-apply.test.ts
+++ b/test/control/writer/comonad-apply.test.ts
@@ -12,4 +12,24 @@ tap.test('Writer ComonadApply', async (t) => {
         const result = ca['<@>'](wf, wa)
         t.equal(ca.extract(result), 2)
     })
+
+    t.test('<@@>', async (t) => {
+        const wa = writer(() => tuple2(1, 'v'))
+        const wf = writer(() => tuple2((x: number) => x + 1, 'log'))
+        const result = ca['<@@>'](wa, wf)
+        t.equal(ca.extract(result), 2)
+    })
+
+    t.test('liftW3', async (t) => {
+        const wa = writer(() => tuple2(1, 'a'))
+        const wb = writer(() => tuple2(2, 'b'))
+        const wc = writer(() => tuple2(3, 'c'))
+        const result = ca.liftW3(
+            (a: number) => (b: number) => (c: number) => a + b + c,
+            wa,
+            wb,
+            wc,
+        )
+        t.equal(ca.extract(result), 6)
+    })
 })

--- a/test/ghc/base/comonad-apply.test.ts
+++ b/test/ghc/base/comonad-apply.test.ts
@@ -22,6 +22,24 @@ tap.test('ComonadApply', async (t) => {
         t.same(run(left), run(right))
     })
 
+    t.test('<@@> wa wf = liftW2 (flip id) wa wf', async (t) => {
+        const wa = writer(() => tuple2(1, 'a'))
+        const wf = writer(() => tuple2((x: number) => x + 1, 'f'))
+        const left = ca['<@@>'](wa, wf)
+        const right = ca.liftW2((a: number) => (f: (a: number) => number) => f(a), wa, wf)
+        t.same(run(left), run(right))
+    })
+
+    t.test('liftW3 f a b c = f <$> a <@> b <@> c', async (t) => {
+        const f = (x: number) => (y: number) => (z: number) => x + y + z
+        const a = writer(() => tuple2(1, 'a'))
+        const b = writer(() => tuple2(2, 'b'))
+        const c = writer(() => tuple2(3, 'c'))
+        const left = ca.liftW3(f, a, b, c)
+        const right = ca['<@>'](ca['<@>'](ca['<$>'](f, a), b), c)
+        t.same(run(left), run(right))
+    })
+
     t.test('derives liftW2 from <@>', async (t) => {
         const cm = writerComonad<string>()
         const base = {
@@ -63,6 +81,50 @@ tap.test('ComonadApply', async (t) => {
 
         const left = derived['<@>'](wf, wa)
         const right = derived.liftW2(id as any, wf, wa)
+        t.same(run(left), run(right))
+    })
+
+    t.test('derives <@@> from liftW2', async (t) => {
+        const cm = writerComonad<string>()
+        const base = {
+            liftW2: <A, B, C>(
+                f: (a: A) => (b: B) => C,
+                wa: WriterBox<string, A>,
+                wb: WriterBox<string, B>,
+            ): WriterBox<string, C> =>
+                writer(() => {
+                    const [a, w] = wa.runWriter()
+                    const [b] = wb.runWriter()
+                    return tuple2(f(a)(b), w)
+                }),
+        }
+        const derived = createComonadApply(base as any, cm as any) as any
+
+        const wa = writer(() => tuple2(1, 'a'))
+        const wf = writer(() => tuple2((x: number) => x + 1, 'f'))
+        const left = derived['<@@>'](wa, wf)
+        const right = derived.liftW2((a: number) => (f: (a: number) => number) => f(a), wa, wf)
+        t.same(run(left), run(right))
+    })
+
+    t.test('derives liftW3 from <@>', async (t) => {
+        const cm = writerComonad<string>()
+        const base = {
+            '<@>': <A, B>(wf: WriterBox<string, (a: A) => B>, wa: WriterBox<string, A>): WriterBox<string, B> =>
+                writer(() => {
+                    const [f, w] = wf.runWriter()
+                    const [a] = wa.runWriter()
+                    return tuple2(f(a), w)
+                }),
+        }
+        const derived = createComonadApply(base as any, cm as any) as any
+
+        const f = (x: number) => (y: number) => (z: number) => x + y + z
+        const a = writer(() => tuple2(1, 'a'))
+        const b = writer(() => tuple2(2, 'b'))
+        const c = writer(() => tuple2(3, 'c'))
+        const left = derived.liftW3(f, a, b, c)
+        const right = derived['<@>'](derived['<@>'](derived['<$>'](f, a), b), c)
         t.same(run(left), run(right))
     })
 })

--- a/test/ghc/base/non-empty/comonad-apply.test.ts
+++ b/test/ghc/base/non-empty/comonad-apply.test.ts
@@ -21,10 +21,34 @@ tap.test('NonEmpty ComonadApply', async (t) => {
         t.same(toArray(toList(result)), [2, 4, 6])
     })
 
+    t.test('<@@>', async (t) => {
+        const wa = createNonEmpty([1, 2, 3])
+        const wf = createNonEmpty<(_: number) => number>([
+            (x) => x + 1,
+            (x) => x + 2,
+            (x) => x + 3,
+        ])
+        const result = ca['<@@>'](wa, wf)
+        t.same(toArray(toList(result)), [2, 4, 6])
+    })
+
     t.test('liftW2', async (t) => {
         const wa = createNonEmpty([1, 2, 3])
         const wb = createNonEmpty([4, 5, 6])
         const result = ca.liftW2((a: number) => (b: number) => a + b, wa, wb)
         t.same(toArray(toList(result)), [5, 7, 9])
+    })
+
+    t.test('liftW3', async (t) => {
+        const wa = createNonEmpty([1, 2, 3])
+        const wb = createNonEmpty([4, 5, 6])
+        const wc = createNonEmpty([7, 8, 9])
+        const result = ca.liftW3(
+            (a: number) => (b: number) => (c: number) => a + b + c,
+            wa,
+            wb,
+            wc,
+        )
+        t.same(toArray(toList(result)), [12, 15, 18])
     })
 })

--- a/test/ghc/base/tuple/tuple2-comonad-apply.test.ts
+++ b/test/ghc/base/tuple/tuple2-comonad-apply.test.ts
@@ -14,11 +14,33 @@ tap.test('Tuple2 ComonadApply', async (t) => {
         t.equal(snd(result), 2)
     })
 
+    t.test('<@@>', async (t) => {
+        const wa = tuple2('ctxa' as unknown as MinBox0<string>, 1)
+        const wf = tuple2('ctxf' as unknown as MinBox0<string>, (x: number) => x + 1)
+        const result = ca['<@@>'](wa, wf)
+        t.equal(fst(result), 'ctxa')
+        t.equal(snd(result), 2)
+    })
+
     t.test('liftW2', async (t) => {
         const wa = tuple2('ctx' as unknown as MinBox0<string>, 1)
         const wb = tuple2('ctx2' as unknown as MinBox0<string>, 2)
         const result = ca.liftW2((a: number) => (b: number) => a + b, wa, wb)
         t.equal(fst(result), 'ctx')
         t.equal(snd(result), 3)
+    })
+
+    t.test('liftW3', async (t) => {
+        const wa = tuple2('ctx' as unknown as MinBox0<string>, 1)
+        const wb = tuple2('ctx2' as unknown as MinBox0<string>, 2)
+        const wc = tuple2('ctx3' as unknown as MinBox0<string>, 3)
+        const result = ca.liftW3(
+            (a: number) => (b: number) => (c: number) => a + b + c,
+            wa,
+            wb,
+            wc,
+        )
+        t.equal(fst(result), 'ctx')
+        t.equal(snd(result), 6)
     })
 })


### PR DESCRIPTION
## Summary
- add `<@@>` and `liftW3` to `ComonadApply` with default implementations
- support lifting of ternary functions via new `FunctionArrow3`
- extend tests for new combinators across Reader, Writer, Tuple2, and NonEmpty

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f9c97e288328a80e21f12888bbcd