### PR TITLE
Add Foldable typeclass and basic instances

### DIFF
--- a/src/control/reader/foldable.ts
+++ b/src/control/reader/foldable.ts
@@ -1,0 +1,29 @@
+import { ReaderBox } from './reader'
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { Monoid } from 'ghc/base/monoid'
+import { ListBox } from 'ghc/base/list/list'
+
+export interface ReaderFoldable<R> extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ReaderBox<R, A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ReaderBox<R, A>): M
+    fold<M>(m: Monoid<M>, fa: ReaderBox<R, M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: ReaderBox<R, A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: ReaderBox<R, A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: ReaderBox<R, A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: ReaderBox<R, A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: ReaderBox<R, A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: ReaderBox<R, A>): A
+    toList<A>(fa: ReaderBox<R, A>): ListBox<A>
+    null<A>(fa: ReaderBox<R, A>): boolean
+    length<A>(fa: ReaderBox<R, A>): number
+    elem<A>(a: A, fa: ReaderBox<R, A>): boolean
+    maximum(fa: ReaderBox<R, number>): number
+    sum(fa: ReaderBox<R, number>): number
+    product(fa: ReaderBox<R, number>): number
+}
+
+const base = <R>(): FoldableBase => ({
+    foldr: <A, B>(f: (a: A, b: B) => B, b: B, fa: ReaderBox<R, A>): B => f(fa.runReader(undefined as R), b),
+})
+
+export const foldable = <R>() => createFoldable(base<R>()) as ReaderFoldable<R>

--- a/src/control/reader/foldable.ts
+++ b/src/control/reader/foldable.ts
@@ -2,11 +2,12 @@ import { ReaderBox } from './reader'
 import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
 import { Monoid } from 'ghc/base/monoid'
 import { ListBox } from 'ghc/base/list/list'
+import { MinBox0 } from 'data/kind'
 
 export interface ReaderFoldable<R> extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ReaderBox<R, A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ReaderBox<R, A>): M
-    fold<M>(m: Monoid<M>, fa: ReaderBox<R, M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: ReaderBox<R, A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: ReaderBox<R, A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: ReaderBox<R, M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: ReaderBox<R, A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: ReaderBox<R, A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: ReaderBox<R, A>): B

--- a/src/control/writer/foldable.ts
+++ b/src/control/writer/foldable.ts
@@ -1,0 +1,32 @@
+import { WriterBox } from './writer'
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { Monoid } from 'ghc/base/monoid'
+import { ListBox } from 'ghc/base/list/list'
+
+export interface WriterFoldable<W> extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: WriterBox<W, A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: WriterBox<W, A>): M
+    fold<M>(m: Monoid<M>, fa: WriterBox<W, M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: WriterBox<W, A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: WriterBox<W, A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: WriterBox<W, A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: WriterBox<W, A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: WriterBox<W, A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: WriterBox<W, A>): A
+    toList<A>(fa: WriterBox<W, A>): ListBox<A>
+    null<A>(fa: WriterBox<W, A>): boolean
+    length<A>(fa: WriterBox<W, A>): number
+    elem<A>(a: A, fa: WriterBox<W, A>): boolean
+    maximum(fa: WriterBox<W, number>): number
+    sum(fa: WriterBox<W, number>): number
+    product(fa: WriterBox<W, number>): number
+}
+
+const base = <W>(): FoldableBase => ({
+    foldr: <A, B>(f: (a: A, b: B) => B, b: B, fa: WriterBox<W, A>): B => {
+        const [a] = fa.runWriter()
+        return f(a, b)
+    },
+})
+
+export const foldable = <W>() => createFoldable(base<W>()) as WriterFoldable<W>

--- a/src/control/writer/foldable.ts
+++ b/src/control/writer/foldable.ts
@@ -2,11 +2,12 @@ import { WriterBox } from './writer'
 import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
 import { Monoid } from 'ghc/base/monoid'
 import { ListBox } from 'ghc/base/list/list'
+import { MinBox0 } from 'data/kind'
 
 export interface WriterFoldable<W> extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: WriterBox<W, A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: WriterBox<W, A>): M
-    fold<M>(m: Monoid<M>, fa: WriterBox<W, M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: WriterBox<W, A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: WriterBox<W, A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: WriterBox<W, M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: WriterBox<W, A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: WriterBox<W, A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: WriterBox<W, A>): B

--- a/src/data/either/foldable.ts
+++ b/src/data/either/foldable.ts
@@ -1,0 +1,33 @@
+import { $case, EitherBox } from './either'
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { Monoid } from 'ghc/base/monoid'
+import { ListBox } from 'ghc/base/list/list'
+
+export interface EitherFoldable<L> extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: EitherBox<L, A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: EitherBox<L, A>): M
+    fold<M>(m: Monoid<M>, fa: EitherBox<L, M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: EitherBox<L, A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: EitherBox<L, A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: EitherBox<L, A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: EitherBox<L, A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: EitherBox<L, A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: EitherBox<L, A>): A
+    toList<A>(fa: EitherBox<L, A>): ListBox<A>
+    null<A>(fa: EitherBox<L, A>): boolean
+    length<A>(fa: EitherBox<L, A>): number
+    elem<A>(a: A, fa: EitherBox<L, A>): boolean
+    maximum(fa: EitherBox<L, number>): number
+    sum(fa: EitherBox<L, number>): number
+    product(fa: EitherBox<L, number>): number
+}
+
+const base = <L>(): FoldableBase => ({
+    foldr: <A, B>(f: (a: A, b: B) => B, b: B, fa: EitherBox<L, A>): B =>
+        $case<L, A, B>({
+            left: () => b,
+            right: (x: A) => f(x, b),
+        })(fa),
+})
+
+export const foldable = <L>() => createFoldable(base<L>()) as EitherFoldable<L>

--- a/src/data/either/foldable.ts
+++ b/src/data/either/foldable.ts
@@ -2,11 +2,12 @@ import { $case, EitherBox } from './either'
 import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
 import { Monoid } from 'ghc/base/monoid'
 import { ListBox } from 'ghc/base/list/list'
+import { MinBox0 } from 'data/kind'
 
 export interface EitherFoldable<L> extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: EitherBox<L, A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: EitherBox<L, A>): M
-    fold<M>(m: Monoid<M>, fa: EitherBox<L, M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: EitherBox<L, A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: EitherBox<L, A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: EitherBox<L, M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: EitherBox<L, A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: EitherBox<L, A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: EitherBox<L, A>): B

--- a/src/data/foldable.ts
+++ b/src/data/foldable.ts
@@ -1,0 +1,93 @@
+import { MinBox1, MinBox0, Kind, Constraint } from 'data/kind'
+import { Monoid } from 'ghc/base/monoid'
+import { ListBox, cons, nil, toArray as listToArray } from 'ghc/base/list/list'
+
+export type FoldableBase = {
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: MinBox1<A>): B
+}
+
+export type Foldable = FoldableBase & {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: MinBox1<A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: MinBox1<A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: MinBox1<M>): MinBox0<M>
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: MinBox1<A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: MinBox1<A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: MinBox1<A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: MinBox1<A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: MinBox1<A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: MinBox1<A>): A
+    toList<A>(fa: MinBox1<A>): ListBox<A>
+    null<A>(fa: MinBox1<A>): boolean
+    length<A>(fa: MinBox1<A>): number
+    elem<A>(a: A, fa: MinBox1<A>): boolean
+    maximum(fa: MinBox1<number>): number
+    sum(fa: MinBox1<number>): number
+    product(fa: MinBox1<number>): number
+    kind: (_: (_: '*') => '*') => Constraint
+}
+
+export const kindOf =
+    (_: Foldable): Kind =>
+    (_: (_: '*') => '*') =>
+        'Constraint' as Constraint
+
+export const foldable = (base: FoldableBase): Foldable => {
+    const toList = <A>(fa: MinBox1<A>): ListBox<A> => base.foldr<A, ListBox<A>>((a, b) => cons(a)(b), nil(), fa)
+
+    const toArray = <A>(fa: MinBox1<A>): A[] => listToArray(toList(fa))
+
+    const foldl = <A, B>(f: (b: B, a: A) => B, b: B, fa: MinBox1<A>): B => toArray(fa).reduce((acc, x) => f(acc, x), b)
+
+    const foldMap = <A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: MinBox1<A>): MinBox0<M> =>
+        foldl<A, MinBox0<M>>((acc, x) => m['<>'](acc, f(x)), m.mempty, fa)
+
+    const foldr1 = <A>(f: (a: A, b: A) => A, fa: MinBox1<A>): A => {
+        const arr = toArray(fa)
+        if (arr.length === 0) {
+            throw new Error('foldr1: empty structure')
+        }
+        return arr.reduceRight((acc, x) => f(x, acc))
+    }
+
+    const foldl1 = <A>(f: (a: A, b: A) => A, fa: MinBox1<A>): A => {
+        const arr = toArray(fa)
+        if (arr.length === 0) {
+            throw new Error('foldl1: empty structure')
+        }
+        return arr.reduce((acc, x) => f(acc, x))
+    }
+
+    const null_ = <A>(fa: MinBox1<A>): boolean => toArray(fa).length === 0
+    const length = <A>(fa: MinBox1<A>): number => toArray(fa).length
+    const elem = <A>(a: A, fa: MinBox1<A>): boolean => toArray(fa).some((x) => x === a)
+    const maximum = (fa: MinBox1<number>): number => {
+        const arr = toArray(fa)
+        if (arr.length === 0) {
+            throw new Error('maximum: empty structure')
+        }
+        return arr.reduce((acc, x) => (x > acc ? x : acc))
+    }
+    const sum = (fa: MinBox1<number>): number => foldl((acc, x) => acc + x, 0, fa)
+    const product = (fa: MinBox1<number>): number => foldl((acc, x) => acc * x, 1, fa)
+
+    return {
+        ...base,
+        foldMap,
+        "foldMap'": foldMap,
+        fold: <M>(m: Monoid<M>, fa: MinBox1<M>) => foldMap<M, M>(m, (x) => x, fa),
+        foldr: base.foldr,
+        "foldr'": base.foldr,
+        foldl,
+        "foldl'": foldl,
+        foldr1,
+        foldl1,
+        toList,
+        null: null_,
+        length,
+        elem,
+        maximum,
+        sum,
+        product,
+        kind: kindOf(null as unknown as Foldable) as (_: (_: '*') => '*') => 'Constraint',
+    }
+}

--- a/src/data/foldable.ts
+++ b/src/data/foldable.ts
@@ -32,7 +32,8 @@ export const kindOf =
         'Constraint' as Constraint
 
 export const foldable = (base: FoldableBase): Foldable => {
-    const toList = <A>(fa: MinBox1<A>): ListBox<A> => base.foldr<A, ListBox<A>>((a, b) => cons(a)(b), nil(), fa)
+    const toList = <A>(fa: MinBox1<A>): ListBox<A> =>
+        base.foldr<A, ListBox<A>>((a, b) => cons(a as NonNullable<A>)(b), nil(), fa)
 
     const toArray = <A>(fa: MinBox1<A>): A[] => listToArray(toList(fa))
 
@@ -74,7 +75,7 @@ export const foldable = (base: FoldableBase): Foldable => {
         ...base,
         foldMap,
         "foldMap'": foldMap,
-        fold: <M>(m: Monoid<M>, fa: MinBox1<M>) => foldMap<M, M>(m, (x) => x, fa),
+        fold: <M>(m: Monoid<M>, fa: MinBox1<M>) => foldMap<M, M>(m, (x) => x as MinBox0<M>, fa),
         foldr: base.foldr,
         "foldr'": base.foldr,
         foldl,

--- a/src/extra/promise/foldable.ts
+++ b/src/extra/promise/foldable.ts
@@ -1,0 +1,29 @@
+import { PromiseBox } from './promise'
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { Monoid } from 'ghc/base/monoid'
+import { ListBox } from 'ghc/base/list/list'
+
+export interface PromiseFoldable extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: PromiseBox<A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: PromiseBox<A>): M
+    fold<M>(m: Monoid<M>, fa: PromiseBox<M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: PromiseBox<A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: PromiseBox<A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: PromiseBox<A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: PromiseBox<A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: PromiseBox<A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: PromiseBox<A>): A
+    toList<A>(fa: PromiseBox<A>): ListBox<A>
+    null<A>(fa: PromiseBox<A>): boolean
+    length<A>(fa: PromiseBox<A>): number
+    elem<A>(a: A, fa: PromiseBox<A>): boolean
+    maximum(fa: PromiseBox<number>): number
+    sum(fa: PromiseBox<number>): number
+    product(fa: PromiseBox<number>): number
+}
+
+const base: FoldableBase = {
+    foldr: <A, B>(_f: (a: A, b: B) => B, b: B, _fa: PromiseBox<A>): B => b,
+}
+
+export const foldable = createFoldable(base) as PromiseFoldable

--- a/src/extra/promise/foldable.ts
+++ b/src/extra/promise/foldable.ts
@@ -2,11 +2,12 @@ import { PromiseBox } from './promise'
 import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
 import { Monoid } from 'ghc/base/monoid'
 import { ListBox } from 'ghc/base/list/list'
+import { MinBox0 } from 'data/kind'
 
 export interface PromiseFoldable extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: PromiseBox<A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: PromiseBox<A>): M
-    fold<M>(m: Monoid<M>, fa: PromiseBox<M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: PromiseBox<A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: PromiseBox<A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: PromiseBox<M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: PromiseBox<A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: PromiseBox<A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: PromiseBox<A>): B

--- a/src/ghc/base/list/foldable.ts
+++ b/src/ghc/base/list/foldable.ts
@@ -1,11 +1,12 @@
 import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
 import { $null, head, tail, ListBox } from './list'
 import { Monoid } from 'ghc/base/monoid'
+import { MinBox0 } from 'data/kind'
 
 export interface ListFoldable<T> extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ListBox<A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ListBox<A>): M
-    fold<M>(m: Monoid<M>, fa: ListBox<M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: ListBox<A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: ListBox<A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: ListBox<M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: ListBox<A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: ListBox<A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: ListBox<A>): B

--- a/src/ghc/base/list/foldable.ts
+++ b/src/ghc/base/list/foldable.ts
@@ -1,0 +1,33 @@
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { $null, head, tail, ListBox } from './list'
+import { Monoid } from 'ghc/base/monoid'
+
+export interface ListFoldable<T> extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ListBox<A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: ListBox<A>): M
+    fold<M>(m: Monoid<M>, fa: ListBox<M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: ListBox<A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: ListBox<A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: ListBox<A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: ListBox<A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: ListBox<A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: ListBox<A>): A
+    toList<A>(fa: ListBox<A>): ListBox<A>
+    null<A>(fa: ListBox<A>): boolean
+    length<A>(fa: ListBox<A>): number
+    elem<A>(a: A, fa: ListBox<A>): boolean
+    maximum(fa: ListBox<number>): number
+    sum(fa: ListBox<number>): number
+    product(fa: ListBox<number>): number
+}
+
+const base: FoldableBase = {
+    foldr: <A, B>(f: (a: A, b: B) => B, b: B, fa: ListBox<A>): B => {
+        if ($null(fa)) {
+            return b
+        }
+        return f(head(fa), base.foldr(f, b, tail(fa)))
+    },
+}
+
+export const foldable = createFoldable(base) as ListFoldable<unknown>

--- a/src/ghc/base/maybe/foldable.ts
+++ b/src/ghc/base/maybe/foldable.ts
@@ -1,0 +1,33 @@
+import { $case, MaybeBox, nothing } from './maybe'
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { Monoid } from 'ghc/base/monoid'
+import { ListBox } from 'ghc/base/list/list'
+
+export interface MaybeFoldable extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: MaybeBox<A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: MaybeBox<A>): M
+    fold<M>(m: Monoid<M>, fa: MaybeBox<M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: MaybeBox<A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: MaybeBox<A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: MaybeBox<A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: MaybeBox<A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: MaybeBox<A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: MaybeBox<A>): A
+    toList<A>(fa: MaybeBox<A>): ListBox<A>
+    null<A>(fa: MaybeBox<A>): boolean
+    length<A>(fa: MaybeBox<A>): number
+    elem<A>(a: A, fa: MaybeBox<A>): boolean
+    maximum(fa: MaybeBox<number>): number
+    sum(fa: MaybeBox<number>): number
+    product(fa: MaybeBox<number>): number
+}
+
+const base: FoldableBase = {
+    foldr: <A, B>(f: (a: A, b: B) => B, b: B, fa: MaybeBox<A>): B =>
+        $case<A, B>({
+            nothing: () => b,
+            just: (x: A) => f(x, b),
+        })(fa),
+}
+
+export const foldable = createFoldable(base) as MaybeFoldable

--- a/src/ghc/base/maybe/foldable.ts
+++ b/src/ghc/base/maybe/foldable.ts
@@ -2,11 +2,12 @@ import { $case, MaybeBox, nothing } from './maybe'
 import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
 import { Monoid } from 'ghc/base/monoid'
 import { ListBox } from 'ghc/base/list/list'
+import { MinBox0 } from 'data/kind'
 
 export interface MaybeFoldable extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: MaybeBox<A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: MaybeBox<A>): M
-    fold<M>(m: Monoid<M>, fa: MaybeBox<M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: MaybeBox<A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: MaybeBox<A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: MaybeBox<M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: MaybeBox<A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: MaybeBox<A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: MaybeBox<A>): B

--- a/src/ghc/base/non-empty/foldable.ts
+++ b/src/ghc/base/non-empty/foldable.ts
@@ -2,11 +2,12 @@ import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldabl
 import { head, tail, NonEmptyBox } from './list'
 import { $null, head as listHead, tail as listTail, ListBox } from 'ghc/base/list/list'
 import { Monoid } from 'ghc/base/monoid'
+import { MinBox0 } from 'data/kind'
 
 export interface NonEmptyFoldable<T> extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: NonEmptyBox<A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: NonEmptyBox<A>): M
-    fold<M>(m: Monoid<M>, fa: NonEmptyBox<M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: NonEmptyBox<A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: NonEmptyBox<A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: NonEmptyBox<M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: NonEmptyBox<A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: NonEmptyBox<A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: NonEmptyBox<A>): B

--- a/src/ghc/base/non-empty/foldable.ts
+++ b/src/ghc/base/non-empty/foldable.ts
@@ -1,0 +1,37 @@
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { head, tail, NonEmptyBox } from './list'
+import { $null, head as listHead, tail as listTail, ListBox } from 'ghc/base/list/list'
+import { Monoid } from 'ghc/base/monoid'
+
+export interface NonEmptyFoldable<T> extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: NonEmptyBox<A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: NonEmptyBox<A>): M
+    fold<M>(m: Monoid<M>, fa: NonEmptyBox<M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: NonEmptyBox<A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: NonEmptyBox<A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: NonEmptyBox<A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: NonEmptyBox<A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: NonEmptyBox<A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: NonEmptyBox<A>): A
+    toList<A>(fa: NonEmptyBox<A>): ListBox<A>
+    null<A>(fa: NonEmptyBox<A>): boolean
+    length<A>(fa: NonEmptyBox<A>): number
+    elem<A>(a: A, fa: NonEmptyBox<A>): boolean
+    maximum(fa: NonEmptyBox<number>): number
+    sum(fa: NonEmptyBox<number>): number
+    product(fa: NonEmptyBox<number>): number
+}
+
+const base: FoldableBase = {
+    foldr: <A, B>(f: (a: A, b: B) => B, b: B, fa: NonEmptyBox<A>): B => {
+        const go = (lst: ListBox<A>): B => {
+            if ($null(lst)) {
+                return b
+            }
+            return f(listHead(lst), go(listTail(lst)))
+        }
+        return f(head(fa), go(tail(fa)))
+    },
+}
+
+export const foldable = createFoldable(base) as NonEmptyFoldable<unknown>

--- a/src/ghc/base/tuple/foldable.ts
+++ b/src/ghc/base/tuple/foldable.ts
@@ -2,11 +2,12 @@ import { Tuple2Box } from './tuple'
 import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
 import { Monoid } from 'ghc/base/monoid'
 import { ListBox } from 'ghc/base/list/list'
+import { MinBox0 } from 'data/kind'
 
 export interface Tuple2Foldable<T> extends Foldable {
-    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: Tuple2Box<T, A>): M
-    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: Tuple2Box<T, A>): M
-    fold<M>(m: Monoid<M>, fa: Tuple2Box<T, M>): M
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: Tuple2Box<T, A>): MinBox0<M>
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => MinBox0<M>, fa: Tuple2Box<T, A>): MinBox0<M>
+    fold<M>(m: Monoid<M>, fa: Tuple2Box<T, M>): MinBox0<M>
     foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: Tuple2Box<T, A>): B
     "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: Tuple2Box<T, A>): B
     foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: Tuple2Box<T, A>): B

--- a/src/ghc/base/tuple/foldable.ts
+++ b/src/ghc/base/tuple/foldable.ts
@@ -1,0 +1,29 @@
+import { Tuple2Box } from './tuple'
+import { FoldableBase, Foldable, foldable as createFoldable } from 'data/foldable'
+import { Monoid } from 'ghc/base/monoid'
+import { ListBox } from 'ghc/base/list/list'
+
+export interface Tuple2Foldable<T> extends Foldable {
+    foldMap<A, M>(m: Monoid<M>, f: (a: A) => M, fa: Tuple2Box<T, A>): M
+    "foldMap'"<A, M>(m: Monoid<M>, f: (a: A) => M, fa: Tuple2Box<T, A>): M
+    fold<M>(m: Monoid<M>, fa: Tuple2Box<T, M>): M
+    foldr<A, B>(f: (a: A, b: B) => B, b: B, fa: Tuple2Box<T, A>): B
+    "foldr'"<A, B>(f: (a: A, b: B) => B, b: B, fa: Tuple2Box<T, A>): B
+    foldl<A, B>(f: (b: B, a: A) => B, b: B, fa: Tuple2Box<T, A>): B
+    "foldl'"<A, B>(f: (b: B, a: A) => B, b: B, fa: Tuple2Box<T, A>): B
+    foldr1<A>(f: (a: A, b: A) => A, fa: Tuple2Box<T, A>): A
+    foldl1<A>(f: (a: A, b: A) => A, fa: Tuple2Box<T, A>): A
+    toList<A>(fa: Tuple2Box<T, A>): ListBox<A>
+    null<A>(fa: Tuple2Box<T, A>): boolean
+    length<A>(fa: Tuple2Box<T, A>): number
+    elem<A>(a: A, fa: Tuple2Box<T, A>): boolean
+    maximum(fa: Tuple2Box<T, number>): number
+    sum(fa: Tuple2Box<T, number>): number
+    product(fa: Tuple2Box<T, number>): number
+}
+
+const base = <T>(): FoldableBase => ({
+    foldr: <A, B>(f: (a: A, b: B) => B, b: B, fa: Tuple2Box<T, A>): B => f(fa[1], b),
+})
+
+export const foldable = <T>() => createFoldable(base<T>()) as Tuple2Foldable<T>


### PR DESCRIPTION
## Summary
- add `Foldable` typeclass with common folding operations
- implement `Foldable` for Maybe, Either, List, NonEmpty, Reader, Writer, Tuple2 and Promise
- relocate `Foldable` definition from `ghc/base` to `data`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a418b4c10483289fd1cd9d9dc2bf7d