### PR TITLE
Implement Traversable typeclass and instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ts-haskell
+
 Mapping Haskell typeclasses to typescript
 
 ```bash
@@ -31,6 +32,10 @@ npm test
      +------------------+      :................ (Monad as a monoid in endofunctors)
      | Comonad Apply    |
      +------------------+
+
+ +-----------+
+ | Foldable  |
+ +-----------+
 ```
 
 ## Instances
@@ -39,18 +44,18 @@ npm test
 `*` = requires the underlying value type to have the same instance
 
 ```
-Type        Functor Applicative Monad Comonad ComonadApply Semigroup Monoid
-----------------------------------------------------------------------------
-Maybe          ✓        ✓         ✓      -        -           ✓*     ✓*
-Either e       ✓        ✓         ✓      -        -           ✓*     ✓*
-List           ✓        ✓         ✓      -        -           ✓      ✓
-NonEmpty       ✓        ✓         ✓      ✓        ✓           ✓      -
-Reader r       ✓        ✓         ✓      ✓        ✓           ✓*     ✓*
-Writer w       ✓        ✓         ✓      ✓        ✓           ✓*     ✓*
-(->) r         ✓        ✓         ✓      ✓        ✓           ✓*     ✓*
-Tuple2 a       ✓        ✓         ✓      ✓        ✓           ✓*     ✓*
-Promise        ✓        ✓         ✓      -        -           ✓*     ✓*
-Unit ()        -        -         -      -        -           ✓      ✓
+Type        Functor Applicative Monad Comonad ComonadApply Foldable Traversable Semigroup Monoid
+------------------------------------------------------------------------------------------------
+Maybe          ✓        ✓         ✓      -        -          ✓        ✓           ✓*     ✓*
+Either e       ✓        ✓         ✓      -        -          ✓        ✓           ✓*     ✓*
+List           ✓        ✓         ✓      -        -          ✓        ✓           ✓      ✓
+NonEmpty       ✓        ✓         ✓      ✓        ✓          ✓        ✓           ✓      -
+Reader r       ✓        ✓         ✓      ✓        ✓          ✓        -           ✓*     ✓*
+Writer w       ✓        ✓         ✓      ✓        ✓          ✓        -           ✓*     ✓*
+(->) r         ✓        ✓         ✓      ✓        ✓          ✓        -           ✓*     ✓*
+Tuple2 a       ✓        ✓         ✓      ✓        ✓          ✓        ✓           ✓*     ✓*
+Promise        ✓        ✓         ✓      -        -          ✓        -           ✓*     ✓*
+Unit ()        -        -         -      -        -          -        -           ✓      ✓
 ```
 
 ## References
@@ -60,14 +65,16 @@ Unit ()        -        -         -      -        -           ✓      ✓
 - [Monad](src/ghc/base/monad/monad.ts)
 - [Comonad](src/control/comonad.ts)
 - [ComonadApply](src/control/comonad-apply.ts)
+- [Foldable](src/data/foldable.ts)
 - [Semigroup](src/ghc/base/semigroup.ts)
 - [Monoid](src/ghc/base/monoid.ts)
-- [Maybe](src/ghc/base/maybe/maybe.ts)
-- [Either](src/data/either/either.ts)
-- [List](src/ghc/base/list/list.ts)
-- [NonEmpty list](src/ghc/base/non-empty/list.ts)
-- [Reader](src/control/reader/reader.ts)
-- [Writer](src/control/writer/writer.ts)
-- [Function arrow \`(->)\`](src/ghc/prim/function-arrow/index.ts)
-- [Tuple2 and Unit](src/ghc/base/tuple/tuple.ts)
-- [Promise](src/extra/promise/promise.ts)
+- [Traversable](src/ghc/base/traversable.ts)
+- [Maybe](src/ghc/base/maybe/maybe.ts) ([Foldable](src/ghc/base/maybe/foldable.ts), [Traversable](src/ghc/base/maybe/traversable.ts))
+- [Either](src/data/either/either.ts) ([Foldable](src/data/either/foldable.ts), [Traversable](src/data/either/traversable.ts))
+- [List](src/ghc/base/list/list.ts) ([Foldable](src/ghc/base/list/foldable.ts), [Traversable](src/ghc/base/list/traversable.ts))
+- [NonEmpty list](src/ghc/base/non-empty/list.ts) ([Foldable](src/ghc/base/non-empty/foldable.ts), [Traversable](src/ghc/base/non-empty/traversable.ts))
+- [Reader](src/control/reader/reader.ts) ([Foldable](src/control/reader/foldable.ts))
+- [Writer](src/control/writer/writer.ts) ([Foldable](src/control/writer/foldable.ts))
+- [Function arrow \`(->)\`](src/ghc/prim/function-arrow/index.ts) ([Foldable](src/control/reader/foldable.ts))
+- [Tuple2 and Unit](src/ghc/base/tuple/tuple.ts) ([Foldable](src/ghc/base/tuple/foldable.ts), [Traversable](src/ghc/base/tuple/tuple2-traversable.ts))
+- [Promise](src/extra/promise/promise.ts) ([Foldable](src/extra/promise/foldable.ts))

--- a/src/data/either/traversable.ts
+++ b/src/data/either/traversable.ts
@@ -1,0 +1,21 @@
+import { Applicative } from 'ghc/base/applicative'
+import { Traversable, traversable as createTraversable, BaseImplementation } from 'ghc/base/traversable'
+import { functor } from './functor'
+import { foldable } from './foldable'
+import { $case, left, right, EitherBox } from './either'
+import { MinBox1 } from 'data/kind'
+
+export interface EitherTraversable<E> extends Traversable {
+    traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: EitherBox<E, A>): MinBox1<EitherBox<E, B>>
+    sequenceA<A>(app: Applicative, tfa: EitherBox<E, MinBox1<A>>): MinBox1<EitherBox<E, A>>
+}
+
+const base = <E>(): BaseImplementation => ({
+    sequenceA: <A>(app: Applicative, tfa: EitherBox<E, MinBox1<A>>): MinBox1<EitherBox<E, A>> =>
+        $case<E, MinBox1<A>, MinBox1<EitherBox<E, A>>>({
+            left: (e) => app.pure(left<E, A>(e as NonNullable<E>)),
+            right: (m) => app['<$>'](right as (a: A) => EitherBox<E, A>, m),
+        })(tfa),
+})
+
+export const traversable = <E>() => createTraversable(base<E>(), functor<E>(), foldable<E>()) as EitherTraversable<E>

--- a/src/ghc/base/list/traversable.ts
+++ b/src/ghc/base/list/traversable.ts
@@ -1,0 +1,24 @@
+import { Applicative } from 'ghc/base/applicative'
+import { Traversable, traversable as createTraversable, BaseImplementation } from 'ghc/base/traversable'
+import { functor } from './functor'
+import { foldable } from './foldable'
+import { ListBox, $null, head, tail, nil, cons } from './list'
+import { MinBox1 } from 'data/kind'
+
+export interface ListTraversable<T> extends Traversable {
+    traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: ListBox<A>): MinBox1<ListBox<B>>
+    sequenceA<A>(app: Applicative, tfa: ListBox<MinBox1<A>>): MinBox1<ListBox<A>>
+}
+
+const sequenceA = <A>(app: Applicative, tfa: ListBox<MinBox1<A>>): MinBox1<ListBox<A>> => {
+    if ($null(tfa)) {
+        return app.pure(nil())
+    }
+    return app.liftA2((x: A) => (xs: ListBox<A>) => cons(x as NonNullable<A>)(xs), head(tfa), sequenceA(app, tail(tfa)))
+}
+
+const base: BaseImplementation = {
+    sequenceA,
+}
+
+export const traversable = createTraversable(base, functor, foldable) as ListTraversable<unknown>

--- a/src/ghc/base/maybe/traversable.ts
+++ b/src/ghc/base/maybe/traversable.ts
@@ -1,0 +1,21 @@
+import { Applicative } from 'ghc/base/applicative'
+import { Traversable, traversable as createTraversable, BaseImplementation } from 'ghc/base/traversable'
+import { functor } from './functor'
+import { foldable } from './foldable'
+import { $case, just, nothing, MaybeBox } from './maybe'
+import { MinBox1 } from 'data/kind'
+
+export interface MaybeTraversable extends Traversable {
+    traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: MaybeBox<A>): MinBox1<MaybeBox<B>>
+    sequenceA<A>(app: Applicative, tfa: MaybeBox<MinBox1<A>>): MinBox1<MaybeBox<A>>
+}
+
+const base: BaseImplementation = {
+    sequenceA: <A>(app: Applicative, tfa: MaybeBox<MinBox1<A>>): MinBox1<MaybeBox<A>> =>
+        $case<MinBox1<A>, MinBox1<MaybeBox<A>>>({
+            nothing: () => app.pure(nothing()),
+            just: (x) => app['<$>'](just as (a: A) => MaybeBox<A>, x),
+        })(tfa),
+}
+
+export const traversable = createTraversable(base, functor, foldable) as MaybeTraversable

--- a/src/ghc/base/non-empty/traversable.ts
+++ b/src/ghc/base/non-empty/traversable.ts
@@ -1,0 +1,19 @@
+import { Applicative } from 'ghc/base/applicative'
+import { Traversable, traversable as createTraversable, BaseImplementation } from 'ghc/base/traversable'
+import { functor } from './functor'
+import { foldable } from './foldable'
+import { NonEmptyBox, toList, formList } from './list'
+import { traversable as listTraversable } from 'ghc/base/list/traversable'
+import { MinBox1 } from 'data/kind'
+
+export interface NonEmptyTraversable extends Traversable {
+    traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: NonEmptyBox<A>): MinBox1<NonEmptyBox<B>>
+    sequenceA<A>(app: Applicative, tfa: NonEmptyBox<MinBox1<A>>): MinBox1<NonEmptyBox<A>>
+}
+
+const base: BaseImplementation = {
+    sequenceA: <A>(app: Applicative, tfa: NonEmptyBox<MinBox1<A>>): MinBox1<NonEmptyBox<A>> =>
+        app['<$>'](formList, listTraversable.sequenceA(app, toList(tfa))),
+}
+
+export const traversable = createTraversable(base, functor, foldable) as NonEmptyTraversable

--- a/src/ghc/base/traversable.ts
+++ b/src/ghc/base/traversable.ts
@@ -1,0 +1,46 @@
+import { MinBox1, Kind, Constraint } from 'data/kind'
+import { Functor } from 'ghc/base/functor'
+import { Foldable } from 'data/foldable'
+import { Applicative } from 'ghc/base/applicative'
+import { id } from 'ghc/base/functions'
+
+export type TraversableBase = Functor &
+    Foldable & {
+        traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: MinBox1<A>): MinBox1<MinBox1<B>>
+        sequenceA<A>(app: Applicative, tfa: MinBox1<MinBox1<A>>): MinBox1<MinBox1<A>>
+    }
+
+export type Traversable = TraversableBase & {
+    kind: (_: (_: '*') => '*') => Constraint
+}
+
+export type BaseImplementation = Partial<Pick<TraversableBase, 'traverse' | 'sequenceA'>> &
+    (Pick<TraversableBase, 'traverse'> | Pick<TraversableBase, 'sequenceA'>)
+
+export const kindOf =
+    (_: Traversable): Kind =>
+    (_: (_: '*') => '*') =>
+        'Constraint' as Constraint
+
+export const traversable = (base: BaseImplementation, functor: Functor, foldable: Foldable): Traversable => {
+    const result: TraversableBase = {
+        ...functor,
+        ...foldable,
+        traverse: base.traverse as TraversableBase['traverse'],
+        sequenceA: base.sequenceA as TraversableBase['sequenceA'],
+    }
+
+    if (!base.traverse && base.sequenceA) {
+        result.traverse = <A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: MinBox1<A>) =>
+            result.sequenceA(app, functor.fmap(f, ta))
+    }
+
+    if (!base.sequenceA && base.traverse) {
+        result.sequenceA = <A>(app: Applicative, tfa: MinBox1<MinBox1<A>>) => result.traverse(app, id, tfa)
+    }
+
+    return {
+        ...result,
+        kind: kindOf(null as unknown as Traversable) as (_: (_: '*') => '*') => 'Constraint',
+    }
+}

--- a/src/ghc/base/tuple/tuple2-traversable.ts
+++ b/src/ghc/base/tuple/tuple2-traversable.ts
@@ -1,0 +1,18 @@
+import { Applicative } from 'ghc/base/applicative'
+import { Traversable, traversable as createTraversable, BaseImplementation } from 'ghc/base/traversable'
+import { functor } from './tuple2-functor'
+import { foldable } from './foldable'
+import { tuple2, Tuple2Box, fst, snd } from './tuple'
+import { MinBox1 } from 'data/kind'
+
+export interface Tuple2Traversable<T> extends Traversable {
+    traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: Tuple2Box<T, A>): MinBox1<Tuple2Box<T, B>>
+    sequenceA<A>(app: Applicative, tfa: Tuple2Box<T, MinBox1<A>>): MinBox1<Tuple2Box<T, A>>
+}
+
+const base = <T>(): BaseImplementation => ({
+    sequenceA: <A>(app: Applicative, tfa: Tuple2Box<T, MinBox1<A>>): MinBox1<Tuple2Box<T, A>> =>
+        app['<$>']((y: A) => tuple2(fst(tfa), y), snd(tfa)),
+})
+
+export const traversable = <T>() => createTraversable(base<T>(), functor<T>(), foldable<T>()) as Tuple2Traversable<T>

--- a/test/data/either/traversable.test.ts
+++ b/test/data/either/traversable.test.ts
@@ -1,0 +1,69 @@
+import tap from 'tap'
+import type { Test } from 'tap'
+import { traversable } from 'data/either/traversable'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { left, right, $case as eitherCase, EitherBox } from 'data/either/either'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+
+const caseMaybe = <A>(t: Test, mb: MaybeBox<A>, onJust: (a: A) => void) =>
+    $case<A, void>({ nothing: () => t.fail('expected just'), just: onJust })(mb)
+
+tap.test('Either traversable', async (t) => {
+    t.test('sequenceA', async (t) => {
+        const tfa = right<string, any>(just(7)) as EitherBox<string, any>
+        const res = traversable<string>().sequenceA(maybeApplicative, tfa) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res, (e) =>
+            eitherCase<string, number, void>({
+                left: () => t.fail('expected right'),
+                right: (v) => t.equal(v, 7),
+            })(e),
+        )
+
+        const tfa2 = left<string, any>('err') as EitherBox<string, any>
+        const res2 = traversable<string>().sequenceA(maybeApplicative, tfa2) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res2, (e) =>
+            eitherCase<string, number, void>({
+                left: (err) => t.equal(err, 'err'),
+                right: () => t.fail('expected left'),
+            })(e),
+        )
+    })
+
+    t.test('traverse', async (t) => {
+        const fa = right<string, number>(3) as EitherBox<string, number>
+        const res = traversable<string>().traverse(
+            maybeApplicative,
+            (x: number) => just(x + 1),
+            fa,
+        ) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res, (e) =>
+            eitherCase<string, number, void>({
+                left: () => t.fail('expected right'),
+                right: (v) => t.equal(v, 4),
+            })(e),
+        )
+
+        const leftVal = left<string, number>('err') as EitherBox<string, number>
+        const res2 = traversable<string>().traverse(
+            maybeApplicative,
+            (x: number) => just(x + 1),
+            leftVal,
+        ) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res2, (e) =>
+            eitherCase<string, number, void>({
+                left: (err) => t.equal(err, 'err'),
+                right: () => t.fail('expected left'),
+            })(e),
+        )
+
+        const res3 = traversable<string>().traverse(
+            maybeApplicative,
+            (_: number) => nothing<number>(),
+            fa,
+        ) as MaybeBox<EitherBox<string, number>>
+        $case<EitherBox<string, number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res3)
+    })
+})

--- a/test/ghc/base/list/traversable.test.ts
+++ b/test/ghc/base/list/traversable.test.ts
@@ -1,0 +1,50 @@
+import tap from 'tap'
+import type { Test } from 'tap'
+import { traversable } from 'ghc/base/list/traversable'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+import { cons, nil, toArray, ListBox } from 'ghc/base/list/list'
+
+const listOf = <A>(...xs: NonNullable<A>[]) =>
+    xs.reduceRight((acc, x) => cons(x)(acc), nil<A>())
+
+const caseMaybe = <A>(t: Test, mb: MaybeBox<A>, onJust: (a: A) => void) =>
+    $case<A, void>({
+        nothing: () => t.fail('expected just'),
+        just: onJust,
+    })(mb)
+
+tap.test('List traversable', async (t) => {
+    t.test('sequenceA', async (t) => {
+        const tfa1 = listOf(just(1), just(2))
+        const result1 = traversable.sequenceA(maybeApplicative, tfa1) as MaybeBox<ListBox<number>>
+        caseMaybe(t, result1, (lst: ListBox<number>) => t.same(toArray(lst), [1, 2]))
+
+        const tfa2 = listOf(just(1), nothing<number>())
+        const result2 = traversable.sequenceA(maybeApplicative, tfa2) as MaybeBox<ListBox<number>>
+        $case<void, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(result2)
+    })
+
+    t.test('traverse', async (t) => {
+          const lst = listOf(1, 2)
+          const res =
+              traversable.traverse(maybeApplicative, (x: number) => just(x + 1), lst) as MaybeBox<ListBox<number>>
+          caseMaybe(t, res, (lst: ListBox<number>) => t.same(toArray(lst), [2, 3]))
+    })
+
+    t.test('sequenceA = traverse id', async (t) => {
+          const tfa = listOf(just(1), just(2))
+          const seq = traversable.sequenceA(maybeApplicative, tfa) as MaybeBox<ListBox<number>>
+          const trav = traversable.traverse(
+              maybeApplicative,
+              (x: MaybeBox<number>) => x,
+              tfa,
+          ) as MaybeBox<ListBox<number>>
+          caseMaybe(t, seq, (lst1: ListBox<number>) =>
+              caseMaybe(t, trav, (lst2: ListBox<number>) => t.same(toArray(lst1), toArray(lst2))),
+          )
+    })
+})

--- a/test/ghc/base/maybe/traversable.test.ts
+++ b/test/ghc/base/maybe/traversable.test.ts
@@ -1,0 +1,57 @@
+import tap from 'tap'
+import { traversable } from 'ghc/base/maybe/traversable'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { applicative as listApplicative } from 'ghc/base/list/applicative'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+import { cons, nil, toArray, ListBox } from 'ghc/base/list/list'
+
+const listOf = <A>(...xs: NonNullable<A>[]) =>
+    xs.reduceRight((acc, x) => cons(x)(acc), nil<A>())
+
+const caseMaybe = <A>(mb: MaybeBox<A>, onNothing: () => void, onJust: (a: A) => void) =>
+    $case<A, void>({ nothing: onNothing, just: onJust })(mb)
+
+tap.test('Maybe traversable', async (t) => {
+    t.test('traverse', async (t) => {
+        const res =
+            traversable.traverse(maybeApplicative, (x: number) => just(x + 1), just(3)) as MaybeBox<MaybeBox<number>>
+        caseMaybe(
+            res,
+            () => t.fail('expected outer just'),
+            (inner: MaybeBox<number>) =>
+                caseMaybe(inner, () => t.fail('expected inner just'), (v) => t.equal(v, 4)),
+        )
+
+        const res2 = traversable.traverse(
+            maybeApplicative,
+            (x: number) => just(x + 1),
+            nothing<number>(),
+        )
+        caseMaybe(
+            res2 as MaybeBox<MaybeBox<number>>,
+            () => t.fail('expected outer just'),
+            (inner: MaybeBox<number>) =>
+                caseMaybe(inner, () => t.pass(''), (_a) => t.fail('expected nothing inside')),
+        )
+    })
+
+    t.test('sequenceA', async (t) => {
+        const tfa1 = just(listOf(1, 2))
+        const result1 = traversable.sequenceA(listApplicative, tfa1) as ListBox<MaybeBox<number>>
+        t.same(
+            toArray(result1).map((m) =>
+                caseMaybe(m, () => 'nothing', (v) => `just ${v}`),
+            ),
+            ['just 1', 'just 2'],
+        )
+
+        const tfa2 = nothing<ListBox<number>>()
+        const result2 = traversable.sequenceA(listApplicative, tfa2) as ListBox<MaybeBox<number>>
+        t.same(
+            toArray(result2).map((m) =>
+                caseMaybe(m, () => 'nothing', (v) => `just ${v}`),
+            ),
+            ['nothing'],
+        )
+    })
+})

--- a/test/ghc/base/non-empty/traversable.test.ts
+++ b/test/ghc/base/non-empty/traversable.test.ts
@@ -1,0 +1,48 @@
+import tap from 'tap'
+import type { Test } from 'tap'
+import { traversable } from 'ghc/base/non-empty/traversable'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+import { cons as listCons, nil as listNil, toArray } from 'ghc/base/list/list'
+import { formList, NonEmptyBox, toList } from 'ghc/base/non-empty/list'
+
+const listOf = <A>(...xs: NonNullable<A>[]) =>
+    xs.reduceRight((acc, x) => listCons(x)(acc), listNil<A>())
+
+const caseMaybe = <A>(t: Test, mb: MaybeBox<A>, onJust: (a: A) => void) =>
+    $case<A, void>({ nothing: () => t.fail('expected just'), just: onJust })(mb)
+
+tap.test('NonEmpty traversable', async (t) => {
+    t.test('sequenceA', async (t) => {
+        const tfa = formList(listOf(just(1), just(2))) as NonEmptyBox<MaybeBox<number>>
+        const res = traversable.sequenceA(maybeApplicative, tfa) as MaybeBox<NonEmptyBox<number>>
+        caseMaybe(t, res, (ne: NonEmptyBox<number>) => t.same(toArray(toList(ne)), [1, 2]))
+
+        const tfa2 = formList(listOf(just(1), nothing<number>())) as NonEmptyBox<MaybeBox<number>>
+        const res2 = traversable.sequenceA(maybeApplicative, tfa2) as MaybeBox<NonEmptyBox<number>>
+        $case<NonEmptyBox<number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res2)
+    })
+
+    t.test('traverse', async (t) => {
+        const ne = formList(listOf(1, 2)) as NonEmptyBox<number>
+        const res = traversable.traverse(
+            maybeApplicative,
+            (x: number) => just(x + 1),
+            ne,
+        ) as MaybeBox<NonEmptyBox<number>>
+        caseMaybe(t, res, (ne2: NonEmptyBox<number>) => t.same(toArray(toList(ne2)), [2, 3]))
+
+        const res2 = traversable.traverse(
+            maybeApplicative,
+            (x: number) => (x === 2 ? nothing<number>() : just(x)),
+            ne,
+        ) as MaybeBox<NonEmptyBox<number>>
+        $case<NonEmptyBox<number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res2)
+    })
+})

--- a/test/ghc/base/traversable.test.ts
+++ b/test/ghc/base/traversable.test.ts
@@ -1,0 +1,10 @@
+import tap from 'tap'
+import { kindOf, Traversable } from 'ghc/base/traversable'
+
+tap.test('traversable', async () => {
+    tap.test('kindOf', async (t) => {
+        const kind = kindOf({} as Traversable) as Function
+        const result = kind({} as (_: '*') => '*')
+        t.equal(result, 'Constraint')
+    })
+})

--- a/test/ghc/base/tuple/tuple2-traversable.test.ts
+++ b/test/ghc/base/tuple/tuple2-traversable.test.ts
@@ -1,0 +1,50 @@
+import tap from 'tap'
+import type { Test } from 'tap'
+import { traversable } from 'ghc/base/tuple/tuple2-traversable'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { tuple2, fst, snd, Tuple2Box } from 'ghc/base/tuple/tuple'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+
+const caseMaybe = <A>(t: Test, mb: MaybeBox<A>, onJust: (a: A) => void) =>
+    $case<A, void>({ nothing: () => t.fail('expected just'), just: onJust })(mb)
+
+tap.test('Tuple2 traversable', async (t) => {
+    t.test('sequenceA', async (t) => {
+        const tfa = tuple2('x', just(5)) as Tuple2Box<string, MaybeBox<number>>
+        const res = traversable<string>().sequenceA(maybeApplicative, tfa) as MaybeBox<Tuple2Box<string, number>>
+        caseMaybe<Tuple2Box<string, number>>(t, res, (p) => {
+            t.equal(fst(p), 'x')
+            t.equal(snd(p), 5)
+        })
+
+        const tfa2 = tuple2('x', nothing<number>()) as Tuple2Box<string, MaybeBox<number>>
+        const res2 = traversable<string>().sequenceA(maybeApplicative, tfa2) as MaybeBox<Tuple2Box<string, number>>
+        $case<Tuple2Box<string, number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res2)
+    })
+
+    t.test('traverse', async (t) => {
+        const fa = tuple2('x', 5) as Tuple2Box<string, number>
+        const res = traversable<string>().traverse(
+            maybeApplicative,
+            (x: number) => just(x + 1),
+            fa,
+        ) as MaybeBox<Tuple2Box<string, number>>
+        caseMaybe<Tuple2Box<string, number>>(t, res, (p) => {
+            t.equal(fst(p), 'x')
+            t.equal(snd(p), 6)
+        })
+
+        const res2 = traversable<string>().traverse(
+            maybeApplicative,
+            (_: number) => nothing<number>(),
+            fa,
+        ) as MaybeBox<Tuple2Box<string, number>>
+        $case<Tuple2Box<string, number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res2)
+    })
+})


### PR DESCRIPTION
## Summary
- add base Traversable class with `traverse` and `sequenceA`
- implement Traversable for List, Maybe, NonEmpty, Tuple2 and Either
- document traversable instances in README and clean up formatting
- add missing `traverse` tests for Either, NonEmpty and Tuple2

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a43eecc7808328b55ac91d7a81a283