### PR TITLE
feat: add mapM and sequence

### DIFF
--- a/src/data/traversable.ts
+++ b/src/data/traversable.ts
@@ -2,6 +2,7 @@ import { MinBox1, Kind, Constraint } from 'data/kind'
 import { Functor } from 'ghc/base/functor'
 import { Foldable } from 'data/foldable'
 import { Applicative } from 'ghc/base/applicative'
+import { Monad } from 'ghc/base/monad/monad'
 import { id } from 'ghc/base/functions'
 
 export type TraversableBase = Functor &
@@ -11,6 +12,8 @@ export type TraversableBase = Functor &
     }
 
 export type Traversable = TraversableBase & {
+    mapM<A, B>(m: Monad, f: (a: A) => MinBox1<B>, ta: MinBox1<A>): MinBox1<MinBox1<B>>
+    sequence<A>(m: Monad, tfa: MinBox1<MinBox1<A>>): MinBox1<MinBox1<A>>
     kind: (_: (_: '*') => '*') => Constraint
 }
 
@@ -41,6 +44,8 @@ export const traversable = (base: BaseImplementation, functor: Functor, foldable
 
     return {
         ...result,
+        mapM: (m, f, ta) => result.traverse(m, f, ta),
+        sequence: (m, tfa) => result.sequenceA(m, tfa),
         kind: kindOf(null as unknown as Traversable) as (_: (_: '*') => '*') => 'Constraint',
     }
 }

--- a/test/data/either/traversable.test.ts
+++ b/test/data/either/traversable.test.ts
@@ -2,6 +2,7 @@ import tap from 'tap'
 import type { Test } from 'tap'
 import { traversable } from 'data/either/traversable'
 import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { monad as maybeMonad } from 'ghc/base/maybe/monad'
 import { left, right, $case as eitherCase, EitherBox } from 'data/either/either'
 import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
 
@@ -61,6 +62,71 @@ tap.test('Either traversable', async (t) => {
             (_: number) => nothing<number>(),
             fa,
         ) as MaybeBox<EitherBox<string, number>>
+        $case<EitherBox<string, number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res3)
+    })
+
+    t.test('mapM', async (t) => {
+        const fa = right<string, number>(3) as EitherBox<string, number>
+        const res = traversable<string>().mapM(
+            maybeMonad,
+            (x: number) => just(x + 1),
+            fa,
+        ) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res, (e) =>
+            eitherCase<string, number, void>({
+                left: () => t.fail('expected right'),
+                right: (v) => t.equal(v, 4),
+            })(e),
+        )
+
+        const leftVal = left<string, number>('err') as EitherBox<string, number>
+        const res2 = traversable<string>().mapM(
+            maybeMonad,
+            (x: number) => just(x + 1),
+            leftVal,
+        ) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res2, (e) =>
+            eitherCase<string, number, void>({
+                left: (err) => t.equal(err, 'err'),
+                right: () => t.fail('expected left'),
+            })(e),
+        )
+
+        const res3 = traversable<string>().mapM(
+            maybeMonad,
+            (_: number) => nothing<number>(),
+            fa,
+        ) as MaybeBox<EitherBox<string, number>>
+        $case<EitherBox<string, number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res3)
+    })
+
+    t.test('sequence', async (t) => {
+        const tfa = right<string, any>(just(7)) as EitherBox<string, any>
+        const res = traversable<string>().sequence(maybeMonad, tfa) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res, (e) =>
+            eitherCase<string, number, void>({
+                left: () => t.fail('expected right'),
+                right: (v) => t.equal(v, 7),
+            })(e),
+        )
+
+        const tfa2 = left<string, any>('err') as EitherBox<string, any>
+        const res2 = traversable<string>().sequence(maybeMonad, tfa2) as MaybeBox<EitherBox<string, number>>
+        caseMaybe<EitherBox<string, number>>(t, res2, (e) =>
+            eitherCase<string, number, void>({
+                left: (err) => t.equal(err, 'err'),
+                right: () => t.fail('expected left'),
+            })(e),
+        )
+
+        const tfa3 = right<string, any>(nothing<number>()) as EitherBox<string, any>
+        const res3 = traversable<string>().sequence(maybeMonad, tfa3) as MaybeBox<EitherBox<string, number>>
         $case<EitherBox<string, number>, void>({
             nothing: () => t.pass(''),
             just: () => t.fail('expected nothing'),

--- a/test/ghc/base/maybe/traversable.test.ts
+++ b/test/ghc/base/maybe/traversable.test.ts
@@ -2,6 +2,8 @@ import tap from 'tap'
 import { traversable } from 'ghc/base/maybe/traversable'
 import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
 import { applicative as listApplicative } from 'ghc/base/list/applicative'
+import { monad as maybeMonad } from 'ghc/base/maybe/monad'
+import { monad as listMonad } from 'ghc/base/list/monad'
 import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
 import { cons, nil, toArray, ListBox } from 'ghc/base/list/list'
 
@@ -35,6 +37,38 @@ tap.test('Maybe traversable', async (t) => {
         )
     })
 
+    t.test('mapM', async (t) => {
+        const res =
+            traversable.mapM(maybeMonad, (x: number) => just(x + 1), just(3)) as MaybeBox<MaybeBox<number>>
+        caseMaybe(
+            res,
+            () => t.fail('expected outer just'),
+            (inner: MaybeBox<number>) =>
+                caseMaybe(inner, () => t.fail('expected inner just'), (v) => t.equal(v, 4)),
+        )
+
+        const res2 = traversable.mapM(
+            maybeMonad,
+            (x: number) => just(x + 1),
+            nothing<number>(),
+        ) as MaybeBox<MaybeBox<number>>
+        caseMaybe(
+            res2,
+            () => t.fail('expected outer just'),
+            (inner: MaybeBox<number>) => caseMaybe(inner, () => t.pass(''), () => t.fail('expected nothing inside')),
+        )
+
+        const res3 = traversable.mapM(
+            maybeMonad,
+            (_: number) => nothing<number>(),
+            just(3),
+        ) as MaybeBox<MaybeBox<number>>
+        $case<MaybeBox<number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res3)
+    })
+
     t.test('sequenceA', async (t) => {
         const tfa1 = just(listOf(1, 2))
         const result1 = traversable.sequenceA(listApplicative, tfa1) as ListBox<MaybeBox<number>>
@@ -47,6 +81,26 @@ tap.test('Maybe traversable', async (t) => {
 
         const tfa2 = nothing<ListBox<number>>()
         const result2 = traversable.sequenceA(listApplicative, tfa2) as ListBox<MaybeBox<number>>
+        t.same(
+            toArray(result2).map((m) =>
+                caseMaybe(m, () => 'nothing', (v) => `just ${v}`),
+            ),
+            ['nothing'],
+        )
+    })
+
+    t.test('sequence', async (t) => {
+        const tfa1 = just(listOf(1, 2))
+        const result1 = traversable.sequence(listMonad, tfa1) as ListBox<MaybeBox<number>>
+        t.same(
+            toArray(result1).map((m) =>
+                caseMaybe(m, () => 'nothing', (v) => `just ${v}`),
+            ),
+            ['just 1', 'just 2'],
+        )
+
+        const tfa2 = nothing<ListBox<number>>()
+        const result2 = traversable.sequence(listMonad, tfa2) as ListBox<MaybeBox<number>>
         t.same(
             toArray(result2).map((m) =>
                 caseMaybe(m, () => 'nothing', (v) => `just ${v}`),

--- a/test/ghc/base/non-empty/traversable.test.ts
+++ b/test/ghc/base/non-empty/traversable.test.ts
@@ -2,6 +2,7 @@ import tap from 'tap'
 import type { Test } from 'tap'
 import { traversable } from 'ghc/base/non-empty/traversable'
 import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { monad as maybeMonad } from 'ghc/base/maybe/monad'
 import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
 import { cons as listCons, nil as listNil, toArray } from 'ghc/base/list/list'
 import { formList, NonEmptyBox, toList } from 'ghc/base/non-empty/list'
@@ -40,6 +41,39 @@ tap.test('NonEmpty traversable', async (t) => {
             (x: number) => (x === 2 ? nothing<number>() : just(x)),
             ne,
         ) as MaybeBox<NonEmptyBox<number>>
+        $case<NonEmptyBox<number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res2)
+    })
+
+    t.test('mapM', async (t) => {
+        const ne = formList(listOf(1, 2)) as NonEmptyBox<number>
+        const res = traversable.mapM(
+            maybeMonad,
+            (x: number) => just(x + 1),
+            ne,
+        ) as MaybeBox<NonEmptyBox<number>>
+        caseMaybe(t, res, (ne2: NonEmptyBox<number>) => t.same(toArray(toList(ne2)), [2, 3]))
+
+        const res2 = traversable.mapM(
+            maybeMonad,
+            (x: number) => (x === 2 ? nothing<number>() : just(x)),
+            ne,
+        ) as MaybeBox<NonEmptyBox<number>>
+        $case<NonEmptyBox<number>, void>({
+            nothing: () => t.pass(''),
+            just: () => t.fail('expected nothing'),
+        })(res2)
+    })
+
+    t.test('sequence', async (t) => {
+        const tfa = formList(listOf(just(1), just(2))) as NonEmptyBox<MaybeBox<number>>
+        const res = traversable.sequence(maybeMonad, tfa) as MaybeBox<NonEmptyBox<number>>
+        caseMaybe(t, res, (ne: NonEmptyBox<number>) => t.same(toArray(toList(ne)), [1, 2]))
+
+        const tfa2 = formList(listOf(just(1), nothing<number>())) as NonEmptyBox<MaybeBox<number>>
+        const res2 = traversable.sequence(maybeMonad, tfa2) as MaybeBox<NonEmptyBox<number>>
         $case<NonEmptyBox<number>, void>({
             nothing: () => t.pass(''),
             just: () => t.fail('expected nothing'),


### PR DESCRIPTION
## Summary
- expand Traversable type class with `mapM` and `sequence`
- cover new Traversable methods across base instances

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6fa502dd08328b90efde216a1a37e