### PR TITLE
Add State type and helpers

### DIFF
--- a/src/control/state/state.ts
+++ b/src/control/state/state.ts
@@ -1,0 +1,27 @@
+import { Box2, MinBox0, Type } from 'data/kind'
+import { Tuple2Box } from 'ghc/base/tuple/tuple'
+
+export interface State<S, A> {
+    readonly runState: (s: S) => Tuple2Box<A, S>
+}
+
+export type StateBox<S, A> = State<S, A> & Box2<S, A>
+
+export type StateMinBox<S, A> = State<S, MinBox0<A>> & Box2<S, MinBox0<A>>
+
+export const state = <S, A>(fn: (s: S) => Tuple2Box<A, S>): StateBox<S, A> => ({
+    runState: fn,
+    kind: (_: '*') => (_: '*') => '*' as Type,
+})
+
+export const runState = <S, A>(sa: State<S, A>, s: S): Tuple2Box<A, S> => sa.runState(s)
+
+export const evalState = <S, A>(sa: State<S, A>, s: S): A => sa.runState(s)[0]
+
+export const execState = <S, A>(sa: State<S, A>, s: S): S => sa.runState(s)[1]
+
+export const mapState = <S, A, B>(f: (as: Tuple2Box<A, S>) => Tuple2Box<B, S>, sa: StateBox<S, A>): StateBox<S, B> =>
+    state((s: S) => f(sa.runState(s)))
+
+export const withState = <S, A>(f: (s: S) => S, sa: StateBox<S, A>): StateBox<S, A> =>
+    state((s: S) => sa.runState(f(s)))

--- a/test/control/state/state.test.ts
+++ b/test/control/state/state.test.ts
@@ -1,0 +1,37 @@
+import tap from 'tap'
+import { state, runState, evalState, execState, mapState, withState, StateBox } from 'control/state/state'
+import { fst, snd, tuple2 } from 'ghc/base/tuple/tuple'
+
+tap.test('state and runState', async (t) => {
+    const computation: StateBox<number, string> = state((s: number) => tuple2(s.toString(), s + 1))
+    const result = runState(computation, 0)
+    t.equal(fst(result), '0')
+    t.equal(snd(result), 1)
+    t.equal(computation.kind('*')('*'), '*')
+})
+
+tap.test('evalState returns the value', async (t) => {
+    const computation = state((s: number) => tuple2(s * 2, s + 1))
+    t.equal(evalState(computation, 2), 4)
+})
+
+tap.test('execState returns the final state', async (t) => {
+    const computation = state((s: number) => tuple2(s * 2, s + 1))
+    t.equal(execState(computation, 2), 3)
+})
+
+tap.test('mapState maps the tuple result', async (t) => {
+    const computation = state((s: number) => tuple2(s, s + 1))
+    const mapped = mapState(([a, s]) => tuple2(a + 1, s * 2), computation)
+    const result = runState(mapped, 3)
+    t.equal(fst(result), 4)
+    t.equal(snd(result), 8)
+})
+
+tap.test('withState modifies the input state', async (t) => {
+    const computation = state((s: number) => tuple2(s, s + 1))
+    const modified = withState((s: number) => s * 2, computation)
+    const result = runState(modified, 3)
+    t.equal(fst(result), 6)
+    t.equal(snd(result), 7)
+})


### PR DESCRIPTION
## Summary
- add State type with runState, evalState, execState, mapState, and withState
- cover new State helpers with tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7de0a2e3083289651e34571c284c8