### PR TITLE
Add State functor, applicative, and monad

### DIFF
--- a/src/control/state/applicative.ts
+++ b/src/control/state/applicative.ts
@@ -1,0 +1,55 @@
+import { Applicative, BaseImplementation, applicative as createApplicative } from 'ghc/base/applicative'
+import { state, StateBox } from './state'
+import { functor as createFunctor } from './functor'
+import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import { tuple2 } from 'ghc/base/tuple/tuple'
+
+export interface StateApplicative<S> extends Applicative {
+    pure<A>(a: A): StateBox<S, A>
+
+    '<*>'<A, B>(f: StateBox<S, FunctionArrow<A, B>>, fa: StateBox<S, A>): StateBox<S, B>
+
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, C>, fa: StateBox<S, A>, fb: StateBox<S, B>): StateBox<S, C>
+
+    '*>'<A, B>(fa: StateBox<S, A>, fb: StateBox<S, B>): StateBox<S, B>
+
+    '<*'<A, B>(fa: StateBox<S, A>, fb: StateBox<S, B>): StateBox<S, A>
+
+    '<**>'<A, B>(fa: StateBox<S, A>, f: StateBox<S, FunctionArrow<A, B>>): StateBox<S, B>
+
+    fmap<A, B>(f: (a: A) => B, fa: StateBox<S, A>): StateBox<S, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: StateBox<S, A>): StateBox<S, B>
+
+    '<$'<A, B>(a: A, fb: StateBox<S, B>): StateBox<S, A>
+
+    '$>'<A, B>(fa: StateBox<S, A>, b: B): StateBox<S, B>
+
+    '<&>'<A, B>(fa: StateBox<S, A>, f: (a: A) => B): StateBox<S, B>
+
+    void<A>(fa: StateBox<S, A>): StateBox<S, []>
+}
+
+const baseImplementation = <S>(): BaseImplementation => ({
+    pure: <A>(a: NonNullable<A>): StateBox<S, A> => state((s: S) => tuple2(a, s)),
+
+    '<*>': <A, B>(f: StateBox<S, FunctionArrow<A, B>>, fa: StateBox<S, A>): StateBox<S, B> =>
+        state((s: S) => {
+            const [fn, s1] = f.runState(s)
+            const [a, s2] = fa.runState(s1)
+            return tuple2(fn(a), s2)
+        }),
+
+    liftA2: <A, B, C>(f: FunctionArrow2<A, B, C>, fa: StateBox<S, A>, fb: StateBox<S, B>): StateBox<S, C> =>
+        state((s: S) => {
+            const [a, s1] = fa.runState(s)
+            const [b, s2] = fb.runState(s1)
+            return tuple2(f(a)(b), s2)
+        }),
+})
+
+export const applicative = <S>(): StateApplicative<S> => {
+    const functor = createFunctor<S>()
+    const base = baseImplementation<S>()
+    return createApplicative(base, functor) as StateApplicative<S>
+}

--- a/src/control/state/functor.ts
+++ b/src/control/state/functor.ts
@@ -1,0 +1,28 @@
+import { Functor, FunctorBase, functor as createFunctor } from 'ghc/base/functor'
+import { state, StateBox } from './state'
+import { tuple2, Tuple2Box } from 'ghc/base/tuple/tuple'
+
+export interface StateFunctor<S> extends Functor {
+    fmap<A, B>(f: (a: A) => B, fa: StateBox<S, A>): StateBox<S, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: StateBox<S, A>): StateBox<S, B>
+
+    '<$'<A, B>(a: A, fb: StateBox<S, B>): StateBox<S, A>
+
+    '$>'<A, B>(fa: StateBox<S, A>, b: B): StateBox<S, B>
+
+    '<&>'<A, B>(fa: StateBox<S, A>, f: (a: A) => B): StateBox<S, B>
+
+    void<A>(fa: StateBox<S, A>): StateBox<S, []>
+}
+
+const fmap = <S>(): FunctorBase => ({
+    // fmap :: State s => (a -> b) -> State s a -> State s b
+    fmap: <A, B>(f: (a: A) => NonNullable<B>, fa: StateBox<S, A>): StateBox<S, B> =>
+        state((s: S) => {
+            const [a, s1] = fa.runState(s)
+            return tuple2(f(a), s1) as Tuple2Box<B, S>
+        }),
+})
+
+export const functor = <S>() => createFunctor(fmap<S>()) as StateFunctor<S>

--- a/src/control/state/monad.ts
+++ b/src/control/state/monad.ts
@@ -1,0 +1,50 @@
+import { Monad, monad as createMonad } from 'ghc/base/monad/monad'
+import { applicative as createApplicative } from './applicative'
+import { state, StateBox } from './state'
+import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+
+export interface StateMonad<S> extends Monad {
+    '>>='<A, B>(ma: StateBox<S, A>, f: FunctionArrow<A, StateBox<S, B>>): StateBox<S, B>
+
+    '>>'<A, B>(ma: StateBox<S, A>, mb: StateBox<S, B>): StateBox<S, B>
+
+    return<A>(a: NonNullable<A>): StateBox<S, A>
+
+    pure<A>(a: NonNullable<A>): StateBox<S, A>
+
+    '<*>'<A, B>(f: StateBox<S, FunctionArrow<A, B>>, fa: StateBox<S, A>): StateBox<S, B>
+
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, C>, fa: StateBox<S, A>, fb: StateBox<S, B>): StateBox<S, C>
+
+    '*>'<A, B>(fa: StateBox<S, A>, fb: StateBox<S, B>): StateBox<S, B>
+
+    '<*'<A, B>(fa: StateBox<S, A>, fb: StateBox<S, B>): StateBox<S, A>
+
+    '<**>'<A, B>(fa: StateBox<S, A>, f: StateBox<S, FunctionArrow<A, B>>): StateBox<S, B>
+
+    fmap<A, B>(f: (a: A) => B, fa: StateBox<S, A>): StateBox<S, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: StateBox<S, A>): StateBox<S, B>
+
+    '<$'<A, B>(a: A, fb: StateBox<S, B>): StateBox<S, A>
+
+    '$>'<A, B>(fa: StateBox<S, A>, b: B): StateBox<S, B>
+
+    '<&>'<A, B>(fa: StateBox<S, A>, f: (a: A) => B): StateBox<S, B>
+
+    void<A>(fa: StateBox<S, A>): StateBox<S, []>
+}
+
+const baseImplementation = <S>() => ({
+    '>>=': <A, B>(ma: StateBox<S, A>, f: FunctionArrow<A, StateBox<S, B>>): StateBox<S, B> =>
+        state((s: S) => {
+            const [a, s1] = ma.runState(s)
+            return f(a).runState(s1)
+        }),
+})
+
+export const monad = <S>(): StateMonad<S> => {
+    const base = baseImplementation<S>()
+    const applicative = createApplicative<S>()
+    return createMonad(base, applicative) as StateMonad<S>
+}

--- a/test/control/state/applicative.test.ts
+++ b/test/control/state/applicative.test.ts
@@ -1,0 +1,43 @@
+import tap from 'tap'
+import { applicative as createApplicative } from 'control/state/applicative'
+import { state, StateBox } from 'control/state/state'
+import { tuple2, fst, snd } from 'ghc/base/tuple/tuple'
+
+const applicative = createApplicative<number>()
+const run = <A>(sa: StateBox<number, A>, s: number) => sa.runState(s)
+
+tap.test('State applicative', async (t) => {
+    const value1 = state((s: number) => tuple2(s + 1, s + 1))
+    const value2 = state((s: number) => tuple2(s * 2, s + 1))
+
+    const pureV = applicative.pure(3)
+    const r0 = run(pureV, 0)
+    t.equal(fst(r0), 3)
+    t.equal(snd(r0), 0)
+
+    const f = state((s: number) => tuple2((x: number) => x + 2, s + 1))
+    const app = applicative['<*>'](f, value1)
+    const r1 = run(app, 0)
+    t.equal(fst(r1), 4)
+    t.equal(snd(r1), 2)
+
+    const lifted = applicative.liftA2((x: number) => (y: number) => x + y, value1, value2)
+    const r2 = run(lifted, 1)
+    t.equal(fst(r2), 6)
+    t.equal(snd(r2), 3)
+
+    const thenRight = applicative['*>'](value1, value2)
+    const r3 = run(thenRight, 2)
+    t.equal(fst(r3), 6)
+    t.equal(snd(r3), 4)
+
+    const thenLeft = applicative['<*'](value1, value2)
+    const r4 = run(thenLeft, 2)
+    t.equal(fst(r4), 3)
+    t.equal(snd(r4), 4)
+
+    const applyLeft = applicative['<**>'](value1, f)
+    const r5 = run(applyLeft, 5)
+    t.equal(fst(r5), 8)
+    t.equal(snd(r5), 7)
+})

--- a/test/control/state/functor.test.ts
+++ b/test/control/state/functor.test.ts
@@ -1,0 +1,41 @@
+import tap from 'tap'
+import { functor as createFunctor } from 'control/state/functor'
+import { state, StateBox } from 'control/state/state'
+import { tuple2, fst, snd } from 'ghc/base/tuple/tuple'
+
+const functor = createFunctor<number>()
+const run = <A>(sa: StateBox<number, A>, s: number) => sa.runState(s)
+
+tap.test('State functor', async (t) => {
+    const value = state((s: number) => tuple2(s, s + 1))
+
+    const mapped = functor.fmap((x: number) => x + 1, value)
+    const result1 = run(mapped, 1)
+    t.equal(fst(result1), 2)
+    t.equal(snd(result1), 2)
+
+    const mapped2 = functor['<$>']((x: number) => x * 2, value)
+    const result2 = run(mapped2, 2)
+    t.equal(fst(result2), 4)
+    t.equal(snd(result2), 3)
+
+    const left = functor['<$'](5, value)
+    const result3 = run(left, 3)
+    t.equal(fst(result3), 5)
+    t.equal(snd(result3), 4)
+
+    const right = functor['$>'](value, 7)
+    const result4 = run(right, 4)
+    t.equal(fst(result4), 7)
+    t.equal(snd(result4), 5)
+
+    const fl = functor['<&>'](value, (x: number) => x - 1)
+    const result5 = run(fl, 5)
+    t.equal(fst(result5), 4)
+    t.equal(snd(result5), 6)
+
+    const voided = functor.void(value)
+    const result6 = run(voided, 6)
+    t.same(fst(result6), [])
+    t.equal(snd(result6), 7)
+})

--- a/test/control/state/monad.test.ts
+++ b/test/control/state/monad.test.ts
@@ -1,0 +1,40 @@
+import tap from 'tap'
+import { monad as createMonad } from 'control/state/monad'
+import { state, StateBox } from 'control/state/state'
+import { tuple2, fst, snd } from 'ghc/base/tuple/tuple'
+import { doNotation } from 'ghc/base/monad/do-notation'
+
+const monad = createMonad<number>()
+const run = <A>(sa: StateBox<number, A>, s: number) => sa.runState(s)
+
+tap.test('State monad', async (t) => {
+    const mreturn = monad.return(5)
+    const r0 = run(mreturn, 0)
+    t.equal(fst(r0), 5)
+    t.equal(snd(r0), 0)
+
+    const m = state((s: number) => tuple2(s + 1, s + 1))
+    const bound = monad['>>='](m, (x: number) => state((s: number) => tuple2(x * 2, s + 1)))
+    const r1 = run(bound, 1)
+    t.equal(fst(r1), 4)
+    t.equal(snd(r1), 3)
+
+    const seq = monad['>>'](state((s: number) => tuple2('ignore', s + 1)), m)
+    const r2 = run(seq, 2)
+    t.equal(fst(r2), 4)
+    t.equal(snd(r2), 4)
+
+    const result = doNotation<StateBox<number, number>>(function* (): Generator<
+        StateBox<number, number>,
+        number,
+        number
+    > {
+        const a = (yield state((s: number) => tuple2(s, s + 1))) as number
+        const b = (yield state((s: number) => tuple2(s * 2, s + 1))) as number
+        return a + b
+    }, monad)
+
+    const r3 = run(result, 1)
+    t.equal(fst(r3), 5)
+    t.equal(snd(r3), 3)
+})


### PR DESCRIPTION
## Summary
- implement State functor, applicative, and monad modules
- add tests exercising State functor, applicative, and monad utilities

## Testing
- `npm run lint`
- `npm run build`
- `npm test -- test/control/state/applicative.test.ts`
- `npm test -- test/control/state/monad.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a80efc3eb88328918db9de3da1bfaa