### PR TITLE
Implement State monad helpers

### DIFF
--- a/src/control/state/state.ts
+++ b/src/control/state/state.ts
@@ -1,5 +1,5 @@
 import { Box2, MinBox0, Type } from 'data/kind'
-import { Tuple2Box } from 'ghc/base/tuple/tuple'
+import { tuple2, Tuple2Box } from 'ghc/base/tuple/tuple'
 
 export interface State<S, A> {
     readonly runState: (s: S) => Tuple2Box<A, S>
@@ -25,3 +25,11 @@ export const mapState = <S, A, B>(f: (as: Tuple2Box<A, S>) => Tuple2Box<B, S>, s
 
 export const withState = <S, A>(f: (s: S) => S, sa: StateBox<S, A>): StateBox<S, A> =>
     state((s: S) => sa.runState(f(s)))
+
+export const get = <S>(): StateBox<S, S> => state((s: S) => tuple2(s, s))
+
+export const put = <S>(s: S): StateBox<S, []> => state(() => tuple2([], s))
+
+export const modify = <S>(f: (s: S) => S): StateBox<S, []> => state((s: S) => tuple2([], f(s)))
+
+export const gets = <S, A>(f: (s: S) => A): StateBox<S, A> => state((s: S) => tuple2(f(s), s))

--- a/test/control/state/state.test.ts
+++ b/test/control/state/state.test.ts
@@ -1,5 +1,17 @@
 import tap from 'tap'
-import { state, runState, evalState, execState, mapState, withState, StateBox } from 'control/state/state'
+import {
+    state,
+    runState,
+    evalState,
+    execState,
+    mapState,
+    withState,
+    get,
+    put,
+    modify,
+    gets,
+    StateBox,
+} from 'control/state/state'
 import { fst, snd, tuple2 } from 'ghc/base/tuple/tuple'
 
 tap.test('state and runState', async (t) => {
@@ -34,4 +46,32 @@ tap.test('withState modifies the input state', async (t) => {
     const result = runState(modified, 3)
     t.equal(fst(result), 6)
     t.equal(snd(result), 7)
+})
+
+tap.test('get returns the current state as the value', async (t) => {
+    const computation = get<number>()
+    const result = runState(computation, 5)
+    t.equal(fst(result), 5)
+    t.equal(snd(result), 5)
+})
+
+tap.test('put replaces the state and returns unit', async (t) => {
+    const computation = put<number>(10)
+    const result = runState(computation, 5)
+    t.same(fst(result), [])
+    t.equal(snd(result), 10)
+})
+
+tap.test('modify updates the state using a function', async (t) => {
+    const computation = modify<number>((s) => s + 3)
+    const result = runState(computation, 7)
+    t.same(fst(result), [])
+    t.equal(snd(result), 10)
+})
+
+tap.test('gets extracts a value from the state without modifying it', async (t) => {
+    const computation = gets<number, number>((s) => s * 2)
+    const result = runState(computation, 4)
+    t.equal(fst(result), 8)
+    t.equal(snd(result), 4)
 })


### PR DESCRIPTION
## Summary
- add `get`, `put`, `modify`, and `gets` helpers for the State monad
- test State helper functions

## Testing
- `npm run lint`
- `npm run build`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a83a7430c883288f3021bd651fa430