### PR TITLE
feat: add Alternative instance for Maybe

### DIFF
--- a/src/ghc/base/maybe/alternative.ts
+++ b/src/ghc/base/maybe/alternative.ts
@@ -1,0 +1,39 @@
+import { alternative as createAlternative, Alternative, BaseImplementation } from 'control/alternative/alternative'
+import { applicative } from './applicative'
+import { $case, just, nothing, MaybeBox } from './maybe'
+import { cons, nil, ListBox } from 'ghc/base/list/list'
+
+export interface MaybeAlternative extends Alternative {
+    empty<A>(): MaybeBox<A>
+    '<|>'<A>(a: MaybeBox<A>, b: MaybeBox<A>): MaybeBox<A>
+    some<A>(fa: MaybeBox<A>): MaybeBox<ListBox<A>>
+    many<A>(fa: MaybeBox<A>): MaybeBox<ListBox<A>>
+}
+
+const base: BaseImplementation = {
+    empty: nothing,
+    '<|>': <A>(fa: MaybeBox<A>, fb: MaybeBox<A>): MaybeBox<A> =>
+        $case<A, MaybeBox<A>>({
+            just: () => fa,
+            nothing: () => fb,
+        })(fa),
+}
+
+const some = <A>(fa: MaybeBox<A>): MaybeBox<ListBox<A>> =>
+    $case<A, MaybeBox<ListBox<A>>>({
+        just: (x) => just(cons(x as NonNullable<A>)(nil())),
+        nothing,
+    })(fa)
+
+const many = <A>(fa: MaybeBox<A>): MaybeBox<ListBox<A>> =>
+    $case<A, MaybeBox<ListBox<A>>>({
+        just: (x) => just(cons(x as NonNullable<A>)(nil())),
+        nothing: () => just(nil()),
+    })(fa)
+
+export const alternative = (() => {
+    const alt = createAlternative(base, applicative) as MaybeAlternative
+    alt.some = some
+    alt.many = many
+    return alt
+})()

--- a/test/ghc/base/maybe/alternative.test.ts
+++ b/test/ghc/base/maybe/alternative.test.ts
@@ -1,0 +1,61 @@
+import tap from 'tap'
+import { alternative } from 'ghc/base/maybe/alternative'
+import { just, nothing, MaybeBox, $case } from 'ghc/base/maybe/maybe'
+import { toArray, ListBox } from 'ghc/base/list/list'
+import { id } from 'ghc/base/functions'
+
+const getValue = <A>(box: MaybeBox<A>): A | undefined =>
+    $case<A, A | undefined>({
+        just: id,
+        nothing: () => undefined,
+    })(box)
+
+const getList = <A>(box: MaybeBox<ListBox<A>>): A[] | undefined =>
+    $case<ListBox<A>, A[] | undefined>({
+        just: (xs) => toArray(xs),
+        nothing: () => undefined,
+    })(box)
+
+tap.test('Maybe alternative', async (t) => {
+    await t.test('empty', async (t) => {
+        const result = alternative.empty<number>()
+        t.equal(getValue(result), undefined)
+    })
+
+    await t.test('<|>', async (t) => {
+        const a = just(1)
+        const b = just(2)
+        const c = nothing<number>()
+
+        const r1 = alternative['<|>'](a, b)
+        const r2 = alternative['<|>'](c, b)
+        const r3 = alternative['<|>'](a, c)
+
+        t.equal(getValue(r1), 1)
+        t.equal(getValue(r2), 2)
+        t.equal(getValue(r3), 1)
+    })
+
+    await t.test('some', async (t) => {
+        const value = just(3)
+        const nothingValue = nothing<number>()
+
+        const r1 = alternative.some(value)
+        const r2 = alternative.some(nothingValue)
+
+        t.same(getList(r1), [3])
+        t.equal(getList(r2), undefined)
+    })
+
+    await t.test('many', async (t) => {
+        const value = just(4)
+        const nothingValue = nothing<number>()
+
+        const r1 = alternative.many(value)
+        const r2 = alternative.many(nothingValue)
+
+        t.same(getList(r1), [4])
+        t.same(getList(r2), [])
+    })
+})
+


### PR DESCRIPTION
## Summary
- implement `Alternative` for `Maybe`
- add tests for maybe alternative behavior

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9b383570083288f54d217b3e7c223