### PR TITLE
docs: present Instances as markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,19 @@ npm test
 `✓` = available instance
 `*` = requires the underlying value type to have the same instance
 
-```
-Type        Functor Applicative Alternative Monad Comonad ComonadApply Foldable Traversable Semigroup Monoid
-------------------------------------------------------------------------------------------------------------
-Maybe          ✓        ✓           ✓      ✓      -        -           ✓        ✓        ✓*      ✓*
-Either e       ✓        ✓           -      ✓      -        -           ✓        ✓        ✓*      ✓*
-List           ✓        ✓           ✓      ✓      -        -           ✓        ✓         ✓      ✓
-NonEmpty       ✓        ✓           -      ✓      ✓        ✓           ✓        ✓         ✓      -
-Reader r       ✓        ✓           -      ✓      ✓        ✓           ✓        -        ✓*      ✓*
-Writer w       ✓        ✓           -      ✓      ✓        ✓           ✓        -        ✓*      ✓*
-State s        ✓        ✓           -      ✓      -        -           -        -        -       -
-(->) r         ✓        ✓           -      ✓      ✓        ✓           ✓        -        ✓*      ✓*
-Tuple2 a       ✓        ✓           -      ✓      ✓        ✓           ✓        ✓        ✓*      ✓*
-Promise        ✓        ✓           -      ✓       -        -           ✓        -        ✓*      ✓*
-Unit ()        -        -           -      -       -        -           -        -         ✓       ✓
-```
+| Type       | Functor | Applicative | Alternative | Monad | Comonad | ComonadApply | Foldable | Traversable | Semigroup | Monoid |
+| ---------- | :-----: | :---------: | :---------: | :---: | :-----: | :----------: | :------: | :---------: | :-------: | :----: |
+| Maybe      | ✓       | ✓           | ✓           | ✓     | -       | -            | ✓        | ✓           | ✓*        | ✓*     |
+| Either e   | ✓       | ✓           | -           | ✓     | -       | -            | ✓        | ✓           | ✓*        | ✓*     |
+| List       | ✓       | ✓           | ✓           | ✓     | -       | -            | ✓        | ✓           | ✓         | ✓      |
+| NonEmpty   | ✓       | ✓           | -           | ✓     | ✓       | ✓            | ✓        | ✓           | ✓         | -      |
+| Reader r   | ✓       | ✓           | -           | ✓     | ✓       | ✓            | ✓        | -           | ✓*        | ✓*     |
+| Writer w   | ✓       | ✓           | -           | ✓     | ✓       | ✓            | ✓        | -           | ✓*        | ✓*     |
+| State s    | ✓       | ✓           | -           | ✓     | -       | -            | -        | -           | -         | -      |
+| (->) r     | ✓       | ✓           | -           | ✓     | ✓       | ✓            | ✓        | -           | ✓*        | ✓*     |
+| Tuple2 a   | ✓       | ✓           | -           | ✓     | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*     |
+| Promise    | ✓       | ✓           | -           | ✓     | -       | -            | ✓        | -           | ✓*        | ✓*     |
+| Unit ()    | -       | -           | -           | -     | -       | -            | -        | -           | ✓         | ✓      |
 
 ## References
 


### PR DESCRIPTION
## Summary
- format the Instances listing in README as a Markdown table for improved readability

## Testing
- `npm test` *(fails: 71 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aac0c670988328b08654d0581f326e