### PR TITLE
feat: add monad plus typeclass

### DIFF
--- a/src/control/monad-plus/list.ts
+++ b/src/control/monad-plus/list.ts
@@ -1,0 +1,24 @@
+import { monadPlus as createMonadPlus } from './monad-plus'
+import { monad } from 'ghc/base/list/monad'
+import { alternative } from 'ghc/base/list/alternative'
+import type { ListMonad } from 'ghc/base/list/monad'
+import type { ListAlternative } from 'ghc/base/list/alternative'
+import type { ListBox } from 'ghc/base/list/list'
+import type { List } from 'ghc/base/list/list'
+
+export type ListMonadPlus<T> = ListMonad &
+    ListAlternative<T> & {
+        mzero<A>(): ListBox<A>
+        mplus<A>(a: ListBox<A>, b: ListBox<A>): ListBox<A>
+        msum<A>(ms: List<ListBox<A>>): ListBox<A>
+    }
+
+export const monadPlus = <T>(): ListMonadPlus<T> => {
+    const alt = alternative<T>()
+    const base = {
+        mzero: alt.empty,
+        mplus: alt['<|>'],
+    }
+
+    return createMonadPlus(base, monad, alt) as ListMonadPlus<T>
+}

--- a/src/control/monad-plus/maybe.ts
+++ b/src/control/monad-plus/maybe.ts
@@ -1,0 +1,24 @@
+import { monadPlus as createMonadPlus, MonadPlus } from './monad-plus'
+import { monad } from 'ghc/base/maybe/monad'
+import { alternative } from 'ghc/base/maybe/alternative'
+import { MaybeBox } from 'ghc/base/maybe/maybe'
+import type { List } from 'ghc/base/list/list'
+import type { MaybeMonad } from 'ghc/base/maybe/monad'
+import type { MaybeAlternative } from 'ghc/base/maybe/alternative'
+
+export type MaybeMonadPlus = MaybeMonad &
+    MaybeAlternative & {
+        mzero<A>(): MaybeBox<A>
+        mplus<A>(a: MaybeBox<A>, b: MaybeBox<A>): MaybeBox<A>
+        msum<A>(ms: List<MaybeBox<A>>): MaybeBox<A>
+    }
+
+const base = {
+    mzero: alternative.empty,
+    mplus: alternative['<|>'],
+}
+
+export const monadPlus = (() => {
+    const mp = createMonadPlus(base, monad, alternative) as MaybeMonadPlus
+    return mp
+})()

--- a/src/control/monad-plus/monad-plus.ts
+++ b/src/control/monad-plus/monad-plus.ts
@@ -1,0 +1,39 @@
+import { MinBox1 } from 'data/kind'
+import { List, head, tail, $null } from 'ghc/base/list/list'
+import { Monad } from 'ghc/base/monad/monad'
+import { Alternative } from 'control/alternative/alternative'
+
+export type MonadPlusBase = {
+    mzero<A>(): MinBox1<A>
+    mplus<A>(ma: MinBox1<A>, mb: MinBox1<A>): MinBox1<A>
+}
+
+export type MonadPlus = Monad &
+    Alternative &
+    MonadPlusBase & {
+        msum<A>(ms: List<MinBox1<A>>): MinBox1<A>
+    }
+
+export type BaseImplementation = Pick<MonadPlusBase, 'mzero' | 'mplus'>
+
+export const monadPlus = (base: BaseImplementation, monad: Monad, alternative: Alternative): MonadPlus => {
+    const msum = <A>(ms: List<MinBox1<A>>): MinBox1<A> => {
+        if ($null(ms)) {
+            return base.mzero<A>()
+        }
+
+        return base.mplus(head(ms), msum(tail(ms)))
+    }
+
+    return {
+        ...monad,
+        ...alternative,
+        ...base,
+        msum,
+    }
+}
+
+export const guard =
+    (m: MonadPlus) =>
+    (b: boolean): MinBox1<[]> =>
+        b ? m.return<[]>([]) : m.mzero<[]>()

--- a/test/control/monad-plus/list.test.ts
+++ b/test/control/monad-plus/list.test.ts
@@ -1,0 +1,42 @@
+import tap from 'tap'
+import { monadPlus as listMonadPlus } from 'control/monad-plus/list'
+import { guard } from 'control/monad-plus/monad-plus'
+import { cons, nil, toArray, ListBox, List } from 'ghc/base/list/list'
+
+const listOf = (...xs: number[]): ListBox<number> =>
+    xs.reduceRight((acc, x) => cons(x)(acc), nil<number>())
+
+const listOfLists = (...xs: ListBox<number>[]): List<ListBox<number>> =>
+    xs.reduceRight((acc, x) => cons(x)(acc), nil<ListBox<number>>())
+
+tap.test('List MonadPlus', async (t) => {
+    const mp = listMonadPlus<number>()
+
+    await t.test('mzero', async (t) => {
+        const result = mp.mzero<number>()
+        t.same(toArray(result), [])
+    })
+
+    await t.test('mplus', async (t) => {
+        const result = mp.mplus(listOf(1, 2), listOf(3))
+        t.same(toArray(result), [1, 2, 3])
+    })
+
+    await t.test('msum', async (t) => {
+        const lists = listOfLists(listOf(1), listOf(2, 3))
+        const result = mp.msum(lists)
+        t.same(toArray(result), [1, 2, 3])
+
+        const empty = mp.msum(nil<ListBox<number>>())
+        t.same(toArray(empty), [])
+    })
+
+    await t.test('guard', async (t) => {
+        const result1 = guard(mp)(true) as unknown as ListBox<[]>
+        const result2 = guard(mp)(false) as unknown as ListBox<[]>
+
+        t.same(toArray(result1), [[]])
+        t.same(toArray(result2), [])
+    })
+})
+

--- a/test/control/monad-plus/maybe.test.ts
+++ b/test/control/monad-plus/maybe.test.ts
@@ -1,0 +1,46 @@
+import tap from 'tap'
+import { monadPlus as maybeMonadPlus } from 'control/monad-plus/maybe'
+import { guard } from 'control/monad-plus/monad-plus'
+import { just, nothing, MaybeBox, $case } from 'ghc/base/maybe/maybe'
+import { cons, nil } from 'ghc/base/list/list'
+
+const getValue = <A>(box: MaybeBox<A>): A | undefined =>
+    $case<A, A | undefined>({
+        just: (x) => x,
+        nothing: () => undefined,
+    })(box)
+
+tap.test('Maybe MonadPlus', async (t) => {
+    await t.test('mzero', async (t) => {
+        const result = maybeMonadPlus.mzero<number>()
+        t.equal(getValue(result), undefined)
+    })
+
+    await t.test('mplus', async (t) => {
+        const result1 = maybeMonadPlus.mplus(just(1), just(2))
+        const result2 = maybeMonadPlus.mplus(nothing<number>(), just(2))
+        const result3 = maybeMonadPlus.mplus(nothing<number>(), nothing<number>())
+
+        t.equal(getValue(result1), 1)
+        t.equal(getValue(result2), 2)
+        t.equal(getValue(result3), undefined)
+    })
+
+    await t.test('msum', async (t) => {
+        const list = cons(nothing<number>())(cons(just(3))(cons(just(4))(nil())))
+        const result = maybeMonadPlus.msum(list)
+        t.equal(getValue(result), 3)
+
+        const emptyResult = maybeMonadPlus.msum(nil<MaybeBox<number>>())
+        t.equal(getValue(emptyResult), undefined)
+    })
+
+    await t.test('guard', async (t) => {
+        const result1 = guard(maybeMonadPlus)(true) as unknown as MaybeBox<[]>
+        const result2 = guard(maybeMonadPlus)(false) as unknown as MaybeBox<[]>
+
+        t.same(getValue(result1), [])
+        t.equal(getValue(result2), undefined)
+    })
+})
+


### PR DESCRIPTION
## Summary
- implement MonadPlus typeclass with `msum` and `guard`
- add Maybe MonadPlus instance
- add List MonadPlus instance
- split MonadPlus tests into dedicated files for Maybe and List

## Testing
- `npm run lint`
- `npm run build`
- `npm test test/control/monad-plus/maybe.test.ts test/control/monad-plus/list.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ce10ddc83289d76bbd55b38bf48