### PR TITLE
feat(either): add Alternative and MonadPlus

### DIFF
--- a/src/control/monad-plus/either.ts
+++ b/src/control/monad-plus/either.ts
@@ -1,0 +1,23 @@
+import { monadPlus as createMonadPlus, MonadPlus } from './monad-plus'
+import { monad } from 'data/either/monad'
+import { alternative, EitherAlternative } from 'data/either/alternative'
+import { EitherBox } from 'data/either/either'
+import { Monoid } from 'ghc/base/monoid'
+import type { List } from 'ghc/base/list/list'
+import type { EitherMonad } from 'data/either/monad'
+
+export type EitherMonadPlus<T> = EitherMonad<T> &
+    EitherAlternative<T> & {
+        mzero<A>(): EitherBox<T, A>
+        mplus<A>(a: EitherBox<T, A>, b: EitherBox<T, A>): EitherBox<T, A>
+        msum<A>(ms: List<EitherBox<T, A>>): EitherBox<T, A>
+    }
+
+export const monadPlus = <T>(monoid: Monoid<T>): EitherMonadPlus<T> => {
+    const alt = alternative<T>(monoid)
+    const base = {
+        mzero: alt.empty,
+        mplus: alt['<|>'],
+    }
+    return createMonadPlus(base, monad<T>(), alt) as EitherMonadPlus<T>
+}

--- a/src/data/either/alternative.ts
+++ b/src/data/either/alternative.ts
@@ -1,0 +1,53 @@
+// instance (Monoid e) => Alternative (Either e) -- Defined in 'Data.Either'
+
+import { alternative as createAlternative, Alternative, BaseImplementation } from 'control/alternative/alternative'
+import { applicative } from './applicative'
+import { $case, left, right, EitherBox } from './either'
+import { Monoid } from 'ghc/base/monoid'
+import { MinBox0 } from 'data/kind'
+import { cons, nil, ListBox } from 'ghc/base/list/list'
+
+export interface EitherAlternative<T> extends Alternative {
+    empty<A>(): EitherBox<T, A>
+    '<|>'<A>(a: EitherBox<T, A>, b: EitherBox<T, A>): EitherBox<T, A>
+    some<A>(fa: EitherBox<T, A>): EitherBox<T, ListBox<A>>
+    many<A>(fa: EitherBox<T, A>): EitherBox<T, ListBox<A>>
+}
+
+const base = <T>(monoid: Monoid<T>): BaseImplementation => ({
+    empty: <A>() => left<T, A>(monoid.mempty as unknown as NonNullable<T>),
+    '<|>': <A>(fa: EitherBox<T, A>, fb: EitherBox<T, A>): EitherBox<T, A> =>
+        $case<T, A, EitherBox<T, A>>({
+            right: () => fa,
+            left: (e1: T) =>
+                $case<T, A, EitherBox<T, A>>({
+                    left: (e2: T) =>
+                        left<T, A>(
+                            monoid['<>'](
+                                e1 as unknown as MinBox0<T>,
+                                e2 as unknown as MinBox0<T>,
+                            ) as unknown as NonNullable<T>,
+                        ),
+                    right: (b: A) => right<T, A>(b as NonNullable<A>),
+                })(fb),
+        })(fa),
+})
+
+const some = <T, A>(fa: EitherBox<T, A>): EitherBox<T, ListBox<A>> =>
+    $case<T, A, EitherBox<T, ListBox<A>>>({
+        left: (e) => left<T, ListBox<A>>(e as NonNullable<T>),
+        right: (a) => right<T, ListBox<A>>(cons(a as NonNullable<A>)(nil<A>())),
+    })(fa)
+
+const many = <T, A>(fa: EitherBox<T, A>): EitherBox<T, ListBox<A>> =>
+    $case<T, A, EitherBox<T, ListBox<A>>>({
+        left: () => right<T, ListBox<A>>(nil<A>()),
+        right: (a) => right<T, ListBox<A>>(cons(a as NonNullable<A>)(nil<A>())),
+    })(fa)
+
+export const alternative = <T>(monoid: Monoid<T>): EitherAlternative<T> => {
+    const alt = createAlternative(base<T>(monoid), applicative<T>()) as EitherAlternative<T>
+    alt.some = some as <A>(fa: EitherBox<T, A>) => EitherBox<T, ListBox<A>>
+    alt.many = many as <A>(fa: EitherBox<T, A>) => EitherBox<T, ListBox<A>>
+    return alt
+}

--- a/test/control/monad-plus/either.test.ts
+++ b/test/control/monad-plus/either.test.ts
@@ -1,0 +1,68 @@
+import tap from 'tap'
+import { monadPlus as eitherMonadPlus } from 'control/monad-plus/either'
+import { guard } from 'control/monad-plus/monad-plus'
+import { left, right, $case, EitherBox } from 'data/either/either'
+import { monoid as listMonoid } from 'ghc/base/list/monoid'
+import { cons, nil, ListBox, toArray } from 'ghc/base/list/list'
+
+const getRight = <E, A>(box: EitherBox<E, A>): A | undefined =>
+    $case<E, A, A | undefined>({
+        left: () => undefined,
+        right: (x) => x,
+    })(box)
+
+const getLeft = <E, A>(box: EitherBox<E, A>): E | undefined =>
+    $case<E, A, E | undefined>({
+        left: (e) => e,
+        right: () => undefined,
+    })(box)
+
+tap.test('Either MonadPlus', async (t) => {
+    const monoid = listMonoid<string>()
+    const mp = eitherMonadPlus<ListBox<string>>(monoid)
+
+    await t.test('mzero', async (t) => {
+        const result = mp.mzero<number>()
+        t.same(toArray(getLeft(result) as ListBox<string>), [])
+    })
+
+    await t.test('mplus', async (t) => {
+        const r1 = right<ListBox<string>, number>(1)
+        const r2 = right<ListBox<string>, number>(2)
+        const l1 = left<ListBox<string>, number>(cons('e1')(nil()))
+        const l2 = left<ListBox<string>, number>(cons('e2')(nil()))
+
+        const a = mp.mplus(r1, r2)
+        const b = mp.mplus(l1, r2)
+        const c = mp.mplus(l1, l2)
+
+        t.equal(getRight(a), 1)
+        t.equal(getRight(b), 2)
+        t.same(toArray(getLeft(c) as ListBox<string>), ['e1', 'e2'])
+    })
+
+    await t.test('msum', async (t) => {
+        const l1 = left<ListBox<string>, number>(cons('e1')(nil()))
+        const l2 = left<ListBox<string>, number>(cons('e2')(nil()))
+        const r = right<ListBox<string>, number>(3)
+        const list = cons(l1)(cons(l2)(cons(r)(nil())))
+        const allLeft = cons(l1)(cons(l2)(nil()))
+
+        const result = mp.msum(list)
+        const resultLeft = mp.msum(allLeft)
+        const empty = mp.msum(nil<EitherBox<ListBox<string>, number>>())
+
+        t.equal(getRight(result), 3)
+        t.same(toArray(getLeft(resultLeft) as ListBox<string>), ['e1', 'e2'])
+        t.same(toArray(getLeft(empty) as ListBox<string>), [])
+    })
+
+    await t.test('guard', async (t) => {
+        const ok = guard(mp)(true) as unknown as EitherBox<ListBox<string>, []>
+        const bad = guard(mp)(false) as unknown as EitherBox<ListBox<string>, []>
+
+        t.same(getRight(ok), [])
+        t.same(toArray(getLeft(bad) as ListBox<string>), [])
+    })
+})
+

--- a/test/data/either/alternative.test.ts
+++ b/test/data/either/alternative.test.ts
@@ -1,0 +1,65 @@
+import tap from 'tap'
+import { alternative } from 'data/either/alternative'
+import { left, right, $case, EitherBox } from 'data/either/either'
+import { monoid as listMonoid } from 'ghc/base/list/monoid'
+import { cons, nil, ListBox, toArray } from 'ghc/base/list/list'
+
+const getRight = <E, A>(box: EitherBox<E, A>): A | undefined =>
+    $case<E, A, A | undefined>({
+        left: () => undefined,
+        right: (x) => x,
+    })(box)
+
+const getLeft = <E, A>(box: EitherBox<E, A>): E | undefined =>
+    $case<E, A, E | undefined>({
+        left: (e) => e,
+        right: () => undefined,
+    })(box)
+
+tap.test('Either alternative', async (t) => {
+    const monoid = listMonoid<string>()
+    const alt = alternative<ListBox<string>>(monoid)
+
+    await t.test('empty', async (t) => {
+        const result = alt.empty<number>()
+        t.same(toArray(getLeft(result) as ListBox<string>), [])
+    })
+
+    await t.test('<|>', async (t) => {
+        const r1 = right<ListBox<string>, number>(1)
+        const r2 = right<ListBox<string>, number>(2)
+        const l1 = left<ListBox<string>, number>(cons('e1')(nil()))
+        const l2 = left<ListBox<string>, number>(cons('e2')(nil()))
+
+        const a = alt['<|>'](r1, r2)
+        const b = alt['<|>'](l1, r2)
+        const c = alt['<|>'](l1, l2)
+
+        t.equal(getRight(a), 1)
+        t.equal(getRight(b), 2)
+        t.same(toArray(getLeft(c) as ListBox<string>), ['e1', 'e2'])
+    })
+
+    await t.test('some', async (t) => {
+        const r = right<ListBox<string>, number>(3)
+        const l = left<ListBox<string>, number>(cons('err')(nil()))
+
+        const sr = alt.some(r)
+        const sl = alt.some(l)
+
+        t.same(toArray(getRight(sr) as ListBox<number>), [3])
+        t.same(toArray(getLeft(sl) as ListBox<string>), ['err'])
+    })
+
+    await t.test('many', async (t) => {
+        const r = right<ListBox<string>, number>(4)
+        const l = left<ListBox<string>, number>(cons('err')(nil()))
+
+        const mr = alt.many(r)
+        const ml = alt.many(l)
+
+        t.same(toArray(getRight(mr) as ListBox<number>), [4])
+        t.same(toArray(getRight(ml) as ListBox<number>), [])
+    })
+})
+


### PR DESCRIPTION
## Summary
- implement Alternative for Either with monoidal error accumulation
- implement MonadPlus for Either built on the new Alternative
- test Alternative and MonadPlus behaviors for Either

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad2a6d7a3083289a6f344ef2076e24