### PR TITLE
feat: add traversable instances for reader and writer

### DIFF
--- a/src/control/reader/traversable.ts
+++ b/src/control/reader/traversable.ts
@@ -1,0 +1,18 @@
+import { Applicative } from 'ghc/base/applicative'
+import { Traversable, traversable as createTraversable, BaseImplementation } from 'data/traversable'
+import { ReaderBox, reader } from './reader'
+import { functor } from './functor'
+import { foldable } from './foldable'
+import { MinBox1 } from 'data/kind'
+
+export interface ReaderTraversable<R> extends Traversable {
+    traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: ReaderBox<R, A>): MinBox1<ReaderBox<R, B>>
+    sequenceA<A>(app: Applicative, tfa: ReaderBox<R, MinBox1<A>>): MinBox1<ReaderBox<R, A>>
+}
+
+const base = <R>(): BaseImplementation => ({
+    sequenceA: <A>(app: Applicative, tfa: ReaderBox<R, MinBox1<A>>): MinBox1<ReaderBox<R, A>> =>
+        app['<$>']((x: A) => reader(() => x), tfa.runReader(undefined as R)),
+})
+
+export const traversable = <R>() => createTraversable(base<R>(), functor<R>(), foldable<R>()) as ReaderTraversable<R>

--- a/src/control/writer/traversable.ts
+++ b/src/control/writer/traversable.ts
@@ -1,0 +1,21 @@
+import { Applicative } from 'ghc/base/applicative'
+import { Traversable, traversable as createTraversable, BaseImplementation } from 'data/traversable'
+import { WriterBox, writer } from './writer'
+import { functor } from './functor'
+import { foldable } from './foldable'
+import { MinBox1 } from 'data/kind'
+import { Tuple2Box, tuple2 } from 'ghc/base/tuple/tuple'
+
+export interface WriterTraversable<W> extends Traversable {
+    traverse<A, B>(app: Applicative, f: (a: A) => MinBox1<B>, ta: WriterBox<W, A>): MinBox1<WriterBox<W, B>>
+    sequenceA<A>(app: Applicative, tfa: WriterBox<W, MinBox1<A>>): MinBox1<WriterBox<W, A>>
+}
+
+const base = <W>(): BaseImplementation => ({
+    sequenceA: <A>(app: Applicative, tfa: WriterBox<W, MinBox1<A>>): MinBox1<WriterBox<W, A>> => {
+        const [fa, w] = tfa.runWriter()
+        return app['<$>']((a: A) => writer((): Tuple2Box<A, W> => tuple2(a, w)), fa)
+    },
+})
+
+export const traversable = <W>() => createTraversable(base<W>(), functor<W>(), foldable<W>()) as WriterTraversable<W>

--- a/test/control/reader/traversable.test.ts
+++ b/test/control/reader/traversable.test.ts
@@ -1,0 +1,51 @@
+import tap from 'tap'
+import type { Test } from 'tap'
+import { traversable } from 'control/reader/traversable'
+import { reader } from 'control/reader/reader'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { monad as maybeMonad } from 'ghc/base/maybe/monad'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+import type { ReaderBox } from 'control/reader/reader'
+
+const caseMaybe = <A>(t: Test, mb: MaybeBox<A>, onJust: (a: A) => void) =>
+    $case<A, void>({ nothing: () => t.fail('expected just'), just: onJust })(mb)
+
+tap.test('Reader traversable', async (t) => {
+    t.test('traverse', async (t) => {
+        const r = reader(() => 5)
+        const res = traversable<unknown>().traverse(maybeApplicative, (x: number) => just(x + 1), r) as MaybeBox<
+            ReaderBox<unknown, number>
+        >
+        caseMaybe(t, res, (rr) => t.equal(rr.runReader(undefined as unknown), 6))
+
+        const res2 = traversable<unknown>().traverse(maybeApplicative, (_: number) => nothing<number>(), r)
+        $case<ReaderBox<unknown, number>, void>({ nothing: () => t.pass(''), just: () => t.fail('expected nothing') })(
+            res2 as MaybeBox<ReaderBox<unknown, number>>,
+        )
+    })
+
+    t.test('mapM', async (t) => {
+        const r = reader(() => 5)
+        const res = traversable<unknown>().mapM(maybeMonad, (x: number) => just(x + 1), r) as MaybeBox<
+            ReaderBox<unknown, number>
+        >
+        caseMaybe(t, res, (rr) => t.equal(rr.runReader(undefined as unknown), 6))
+
+        const res2 = traversable<unknown>().mapM(maybeMonad, (_: number) => nothing<number>(), r)
+        $case<ReaderBox<unknown, number>, void>({ nothing: () => t.pass(''), just: () => t.fail('expected nothing') })(
+            res2 as MaybeBox<ReaderBox<unknown, number>>,
+        )
+    })
+
+    t.test('sequenceA', async (t) => {
+        const r = reader(() => just(5))
+        const res = traversable<unknown>().sequenceA(maybeApplicative, r) as MaybeBox<ReaderBox<unknown, number>>
+        caseMaybe(t, res, (rr) => t.equal(rr.runReader(undefined as unknown), 5))
+    })
+
+    t.test('sequence', async (t) => {
+        const r = reader(() => just(5))
+        const res = traversable<unknown>().sequence(maybeMonad, r) as MaybeBox<ReaderBox<unknown, number>>
+        caseMaybe(t, res, (rr) => t.equal(rr.runReader(undefined as unknown), 5))
+    })
+})

--- a/test/control/writer/traversable.test.ts
+++ b/test/control/writer/traversable.test.ts
@@ -1,0 +1,56 @@
+import tap from 'tap'
+import type { Test } from 'tap'
+import { traversable } from 'control/writer/traversable'
+import { writer } from 'control/writer/writer'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { monad as maybeMonad } from 'ghc/base/maybe/monad'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+import type { WriterBox } from 'control/writer/writer'
+import { Tuple2Box, tuple2 } from 'ghc/base/tuple/tuple'
+
+const caseMaybe = <A>(t: Test, mb: MaybeBox<A>, onJust: (a: A) => void) =>
+    $case<A, void>({ nothing: () => t.fail('expected just'), just: onJust })(mb)
+
+tap.test('Writer traversable', async (t) => {
+    t.test('traverse', async (t) => {
+        const w = writer((): Tuple2Box<number, string> => tuple2(3, 'log'))
+        const res = traversable<string>().traverse(
+            maybeApplicative,
+            (x: number) => just(x + 1),
+            w,
+        ) as MaybeBox<WriterBox<string, number>>
+        caseMaybe(t, res, (ww) => t.same(ww.runWriter(), [4, 'log']))
+
+        const res2 = traversable<string>().traverse(maybeApplicative, (_: number) => nothing<number>(), w)
+        $case<WriterBox<string, number>, void>({ nothing: () => t.pass(''), just: () => t.fail('expected nothing') })(
+            res2 as MaybeBox<WriterBox<string, number>>,
+        )
+    })
+
+    t.test('mapM', async (t) => {
+        const w = writer((): Tuple2Box<number, string> => tuple2(3, 'log'))
+        const res = traversable<string>().mapM(
+            maybeMonad,
+            (x: number) => just(x + 1),
+            w,
+        ) as MaybeBox<WriterBox<string, number>>
+        caseMaybe(t, res, (ww) => t.same(ww.runWriter(), [4, 'log']))
+
+        const res2 = traversable<string>().mapM(maybeMonad, (_: number) => nothing<number>(), w)
+        $case<WriterBox<string, number>, void>({ nothing: () => t.pass(''), just: () => t.fail('expected nothing') })(
+            res2 as MaybeBox<WriterBox<string, number>>,
+        )
+    })
+
+    t.test('sequenceA', async (t) => {
+        const w = writer((): Tuple2Box<MaybeBox<number>, string> => tuple2(just(3), 'log'))
+        const res = traversable<string>().sequenceA(maybeApplicative, w) as MaybeBox<WriterBox<string, number>>
+        caseMaybe(t, res, (ww) => t.same(ww.runWriter(), [3, 'log']))
+    })
+
+    t.test('sequence', async (t) => {
+        const w = writer((): Tuple2Box<MaybeBox<number>, string> => tuple2(just(3), 'log'))
+        const res = traversable<string>().sequence(maybeMonad, w) as MaybeBox<WriterBox<string, number>>
+        caseMaybe(t, res, (ww) => t.same(ww.runWriter(), [3, 'log']))
+    })
+})


### PR DESCRIPTION
## Summary
- implement Reader traversable using applicative sequencing
- implement Writer traversable, preserving logs
- add tests for Reader and Writer traversable

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad395082688328927512f62c954ea6