### PR TITLE
Apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ npm test
 +---------------+   (fix one arg)
 |   BIFUNCTOR   |------ 
 +---------------+     | 
-                      v           
-                 +-----------+           +-----------+                                     
-       --------- |  FUNCTOR  | .......   | SEMiGROUP |                                 
-       |      |  +-----------+       .   +-----------+                                                               
-       v      |          |      ...............|.................. (Applicative as a monoidal pattern)
- +---------+  |          v      v    ....      v              
- | COMONAD |  |    +-------------+       .  +----------+               
- +---------+  |    | APPLICATIVE | ---|  .  |  MONOID  |        
-              |    +-------------+    |  .  +----------+ 
-        ------|            |          |  ..........................(Monad as a monoid in endofunctors)
-        |                  v          |           v      
-        |           +--------------+  |       +-----------+                                  
-        |           │ ALTERNATIVE  │  |-----> │   MONAD   │                           
-        |           +--------------+          +-----------+   
+                      v                        
+                 +-----------+                       +-----------+                                     
+       ----------|  FUNCTOR  |  ...............      | SEMIGROUP |                                 
+       |      |  +-----------+                .      +-----------+                                                               
+       v      |                       ......................|............. (Applicative as a monoidal pattern)
+ +---------+  |                       v       ........      v   .
+ | COMONAD |  |  +-------+     +-------------+       .  +----------+               
+ +---------+  |  | APPLY |---->| APPLICATIVE | ----| .  |  MONOID  |        
+              |  +-------+     +-------------+     | .  +----------+ 
+        ------|                         |          | ..................... (Monad as a monoid in endofunctors)
+        |                               v          |          v
+        |                        +--------------+  |       +-----------+                                  
+        |                        │ ALTERNATIVE  │  |------>│   MONAD   │                           
+        |                        +--------------+          +-----------+   
         v                                            |                          
   +-------------+       +--------------+             v
   | TRAVERSABLE |<------│   FOLDABLE   │         +--------------+
@@ -41,23 +41,24 @@ npm test
 - `✓` = available instance
 - `*` = requires the underlying value type to have the same instance
 
-| Type       | Functor | Applicative | Alternative | Monad | MonadPlus | Bifunctor | Comonad | ComonadApply | Foldable | Traversable | Semigroup | Monoid |
-| ---------- | :-----: | :---------: | :---------: | :---: | :-------: | :------: | :-----: | :----------: | :------: | :---------: | :-------: | :----: |
-| Maybe      | ✓       | ✓           | ✓           | ✓     | ✓         |          |         |              | ✓        | ✓           | ✓*        | ✓*  |
-| Either e   | ✓       | ✓           | ✓*          | ✓     | ✓*        | ✓        |         |              | ✓        | ✓           | ✓*        | ✓*  |
-| List       | ✓       | ✓           | ✓           | ✓     | ✓         |          |         |              | ✓        | ✓           | ✓         | ✓  |
-| NonEmpty   | ✓       | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓         |  |
-| Reader r   | ✓       | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| Writer w   | ✓       | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| State s    | ✓       | ✓           |             | ✓     |           |          |         |              |          |             |           |  |
-| (->) r     | ✓       | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| Tuple2 a   | ✓       | ✓           |             | ✓     |           | ✓        | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| Promise    | ✓       | ✓           |             | ✓     |           |          |         |              | ✓        |             | ✓*        | ✓*  |
-| Unit ()    |         |             |             |       |           |          |         |              |          |             | ✓         | ✓  |
+| Type       | Functor | Apply | Applicative | Alternative | Monad | MonadPlus | Bifunctor | Comonad | ComonadApply | Foldable | Traversable | Semigroup | Monoid |
+| ---------- | :-----: | :---: | :---------: | :---------: | :---: | :-------: | :------: | :-----: | :----------: | :------: | :---------: | :-------: | :----: |
+| Maybe      | ✓       | ✓     | ✓           | ✓           | ✓     | ✓         |          |         |              | ✓        | ✓           | ✓*        | ✓*  |
+| Either e   | ✓       | ✓     | ✓           | ✓*          | ✓     | ✓*        | ✓        |         |              | ✓        | ✓           | ✓*        | ✓*  |
+| List       | ✓       | ✓     | ✓           | ✓           | ✓     | ✓         |          |         |              | ✓        | ✓           | ✓         | ✓  |
+| NonEmpty   | ✓       | ✓     | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓         |  |
+| Reader r   | ✓       | ✓     | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| Writer w   | ✓       | ✓*    | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| State s    | ✓       | ✓     | ✓           |             | ✓     |           |          |         |              |          |             |           |  |
+| (->) r     | ✓       | ✓     | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| Tuple2 a   | ✓       | ✓*    | ✓           |             | ✓     |           | ✓        | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| Promise    | ✓       | ✓     | ✓           |             | ✓     |           |          |         |              | ✓        |             | ✓*        | ✓*  |
+| Unit ()    |         |       |             |             |       |           |          |         |              |          |             | ✓         | ✓  |
 
 ## References
 
 - [Functor](src/ghc/base/functor.ts)
+- [Apply](src/data/functor/apply.ts)
 - [Bifunctor](src/data/bifunctor.ts)
 - [Applicative](src/ghc/base/applicative.ts)
 - [Alternative](src/control/alternative/alternative.ts)
@@ -69,13 +70,13 @@ npm test
 - [Traversable](src/data/traversable.ts)
 - [Semigroup](src/ghc/base/semigroup.ts)
 - [Monoid](src/ghc/base/monoid.ts)
-- [Maybe](src/ghc/base/maybe/maybe.ts) ([Functor](src/ghc/base/maybe/functor.ts), [Applicative](src/ghc/base/maybe/applicative.ts), [Alternative](src/ghc/base/maybe/alternative.ts), [Monad](src/ghc/base/maybe/monad.ts), [MonadPlus](src/control/monad-plus/maybe.ts), [Foldable](src/ghc/base/maybe/foldable.ts), [Traversable](src/ghc/base/maybe/traversable.ts))
-- [Either](src/data/either/either.ts) ([Functor](src/data/either/functor.ts), [Applicative](src/data/either/applicative.ts), [Alternative](src/data/either/alternative.ts), [Monad](src/data/either/monad.ts), [MonadPlus](src/control/monad-plus/either.ts), [Bifunctor](src/data/either/bifunctor.ts), [Foldable](src/data/either/foldable.ts), [Traversable](src/data/either/traversable.ts))
-- [List](src/ghc/base/list/list.ts) ([Functor](src/ghc/base/list/functor.ts), [Applicative](src/ghc/base/list/applicative.ts), [Alternative](src/ghc/base/list/alternative.ts), [Monad](src/ghc/base/list/monad.ts), [MonadPlus](src/control/monad-plus/list.ts), [Foldable](src/ghc/base/list/foldable.ts), [Traversable](src/ghc/base/list/traversable.ts))
-- [NonEmpty list](src/ghc/base/non-empty/list.ts) ([Functor](src/ghc/base/non-empty/functor.ts), [Applicative](src/ghc/base/non-empty/applicative.ts), [Monad](src/ghc/base/non-empty/monad.ts), [Comonad](src/ghc/base/non-empty/comonad.ts), [ComonadApply](src/ghc/base/non-empty/comonad-apply.ts), [Foldable](src/ghc/base/non-empty/foldable.ts), [Traversable](src/ghc/base/non-empty/traversable.ts))
-- [Reader](src/control/reader/reader.ts) ([Functor](src/control/reader/functor.ts), [Applicative](src/control/reader/applicative.ts), [Monad](src/control/reader/monad.ts), [Comonad](src/control/reader/comonad.ts), [ComonadApply](src/control/reader/comonad-apply.ts), [Foldable](src/control/reader/foldable.ts), [Traversable](src/control/reader/traversable.ts))
-- [Writer](src/control/writer/writer.ts) ([Functor](src/control/writer/functor.ts), [Applicative](src/control/writer/applicative.ts), [Monad](src/control/writer/monad.ts), [Comonad](src/control/writer/comonad.ts), [ComonadApply](src/control/writer/comonad-apply.ts), [Foldable](src/control/writer/foldable.ts), [Traversable](src/control/writer/traversable.ts))
-- [State](src/control/state/state.ts) ([Functor](src/control/state/functor.ts), [Applicative](src/control/state/applicative.ts), [Monad](src/control/state/monad.ts))
-- [Function arrow `(->)`](src/ghc/prim/function-arrow/index.ts) ([Functor](src/ghc/base/function-arrow/functor.ts), [Applicative](src/ghc/base/function-arrow/applicative.ts), [Monad](src/ghc/base/function-arrow/monad.ts), [Comonad](src/control/reader/comonad.ts), [ComonadApply](src/control/reader/comonad-apply.ts), [Foldable](src/control/reader/foldable.ts), [Traversable](src/control/reader/traversable.ts))
-- [Tuple2 and Unit](src/ghc/base/tuple/tuple.ts) ([Functor](src/ghc/base/tuple/tuple2-functor.ts), [Applicative](src/ghc/base/tuple/tuple2-applicative.ts), [Monad](src/ghc/base/tuple/tuple2-monad.ts), [Bifunctor](src/ghc/base/tuple/tuple2-bifunctor.ts), [Comonad](src/ghc/base/tuple/tuple2-comonad.ts), [ComonadApply](src/ghc/base/tuple/tuple2-comonad-apply.ts), [Foldable](src/ghc/base/tuple/foldable.ts), [Traversable](src/ghc/base/tuple/tuple2-traversable.ts), [Semigroup](src/ghc/base/tuple/tuple2-semigroup.ts), [Monoid](src/ghc/base/tuple/tuple2-monoid.ts))
-- [Promise](src/extra/promise/promise.ts) ([Functor](src/extra/promise/functor.ts), [Applicative](src/extra/promise/applicative.ts), [Monad](src/extra/promise/monad.ts), [Foldable](src/extra/promise/foldable.ts), [Semigroup](src/extra/promise/semigroup.ts), [Monoid](src/extra/promise/monoid.ts))
+- [Maybe](src/ghc/base/maybe/maybe.ts) ([Functor](src/ghc/base/maybe/functor.ts), [Apply](src/ghc/base/maybe/apply.ts), [Applicative](src/ghc/base/maybe/applicative.ts), [Alternative](src/ghc/base/maybe/alternative.ts), [Monad](src/ghc/base/maybe/monad.ts), [MonadPlus](src/control/monad-plus/maybe.ts), [Foldable](src/ghc/base/maybe/foldable.ts), [Traversable](src/ghc/base/maybe/traversable.ts))
+- [Either](src/data/either/either.ts) ([Functor](src/data/either/functor.ts), [Apply](src/data/either/apply.ts), [Applicative](src/data/either/applicative.ts), [Alternative](src/data/either/alternative.ts), [Monad](src/data/either/monad.ts), [MonadPlus](src/control/monad-plus/either.ts), [Bifunctor](src/data/either/bifunctor.ts), [Foldable](src/data/either/foldable.ts), [Traversable](src/data/either/traversable.ts))
+- [List](src/ghc/base/list/list.ts) ([Functor](src/ghc/base/list/functor.ts), [Apply](src/ghc/base/list/apply.ts), [Applicative](src/ghc/base/list/applicative.ts), [Alternative](src/ghc/base/list/alternative.ts), [Monad](src/ghc/base/list/monad.ts), [MonadPlus](src/control/monad-plus/list.ts), [Foldable](src/ghc/base/list/foldable.ts), [Traversable](src/ghc/base/list/traversable.ts))
+- [NonEmpty list](src/ghc/base/non-empty/list.ts) ([Functor](src/ghc/base/non-empty/functor.ts), [Apply](src/ghc/base/non-empty/apply.ts), [Applicative](src/ghc/base/non-empty/applicative.ts), [Monad](src/ghc/base/non-empty/monad.ts), [Comonad](src/ghc/base/non-empty/comonad.ts), [ComonadApply](src/ghc/base/non-empty/comonad-apply.ts), [Foldable](src/ghc/base/non-empty/foldable.ts), [Traversable](src/ghc/base/non-empty/traversable.ts))
+- [Reader](src/control/reader/reader.ts) ([Functor](src/control/reader/functor.ts), [Apply](src/control/reader/apply.ts), [Applicative](src/control/reader/applicative.ts), [Monad](src/control/reader/monad.ts), [Comonad](src/control/reader/comonad.ts), [ComonadApply](src/control/reader/comonad-apply.ts), [Foldable](src/control/reader/foldable.ts), [Traversable](src/control/reader/traversable.ts))
+- [Writer](src/control/writer/writer.ts) ([Functor](src/control/writer/functor.ts), [Apply](src/control/writer/apply.ts), [Applicative](src/control/writer/applicative.ts), [Monad](src/control/writer/monad.ts), [Comonad](src/control/writer/comonad.ts), [ComonadApply](src/control/writer/comonad-apply.ts), [Foldable](src/control/writer/foldable.ts), [Traversable](src/control/writer/traversable.ts))
+- [State](src/control/state/state.ts) ([Functor](src/control/state/functor.ts), [Apply](src/control/state/apply.ts), [Applicative](src/control/state/applicative.ts), [Monad](src/control/state/monad.ts))
+- [Function arrow `(->)`](src/ghc/prim/function-arrow/index.ts) ([Functor](src/ghc/base/function-arrow/functor.ts), [Apply](src/ghc/base/function-arrow/apply.ts), [Applicative](src/ghc/base/function-arrow/applicative.ts), [Monad](src/ghc/base/function-arrow/monad.ts), [Comonad](src/control/reader/comonad.ts), [ComonadApply](src/control/reader/comonad-apply.ts), [Foldable](src/control/reader/foldable.ts), [Traversable](src/control/reader/traversable.ts))
+- [Tuple2 and Unit](src/ghc/base/tuple/tuple.ts) ([Functor](src/ghc/base/tuple/tuple2-functor.ts), [Apply](src/ghc/base/tuple/tuple2-apply.ts), [Applicative](src/ghc/base/tuple/tuple2-applicative.ts), [Monad](src/ghc/base/tuple/tuple2-monad.ts), [Bifunctor](src/ghc/base/tuple/tuple2-bifunctor.ts), [Comonad](src/ghc/base/tuple/tuple2-comonad.ts), [ComonadApply](src/ghc/base/tuple/tuple2-comonad-apply.ts), [Foldable](src/ghc/base/tuple/foldable.ts), [Traversable](src/ghc/base/tuple/tuple2-traversable.ts), [Semigroup](src/ghc/base/tuple/tuple2-semigroup.ts), [Monoid](src/ghc/base/tuple/tuple2-monoid.ts))
+- [Promise](src/extra/promise/promise.ts) ([Functor](src/extra/promise/functor.ts), [Apply](src/extra/promise/apply.ts), [Applicative](src/extra/promise/applicative.ts), [Monad](src/extra/promise/monad.ts), [Foldable](src/extra/promise/foldable.ts), [Semigroup](src/extra/promise/semigroup.ts), [Monoid](src/extra/promise/monoid.ts))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "lint": "eslint --max-warnings=0",
     "lint:fix": "eslint --max-warnings=0  --fix",
-    "test": "tap run --node-arg=\"-r\"  --node-arg=\"tsconfig-paths/register\"",
+    "test": "tap --node-arg=\"-r\"  --node-arg=\"tsconfig-paths/register\"",
     "coverage:html": "tap report html"
   },
   "repository": {

--- a/src/control/reader/apply.ts
+++ b/src/control/reader/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'control/reader/applicative'
+
+export const apply = <R>() => fromApplicative(applicative<R>())

--- a/src/control/state/apply.ts
+++ b/src/control/state/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'control/state/applicative'
+
+export const apply = <S>() => fromApplicative(applicative<S>())

--- a/src/control/writer/apply.ts
+++ b/src/control/writer/apply.ts
@@ -1,0 +1,5 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'control/writer/applicative'
+import { Monoid } from 'ghc/base/monoid'
+
+export const apply = <W>(m: Monoid<W>) => fromApplicative(applicative<W>(m))

--- a/src/data/either/apply.ts
+++ b/src/data/either/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'data/either/applicative'
+
+export const apply = <T>() => fromApplicative(applicative<T>())

--- a/src/data/functor/apply.ts
+++ b/src/data/functor/apply.ts
@@ -1,0 +1,73 @@
+import { MinBox1 } from 'data/kind'
+import { Functor } from 'ghc/base/functor'
+import { Applicative, applicative as createApplicative } from 'ghc/base/applicative'
+import { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import { id, $const } from 'ghc/base/functions'
+
+// Apply: Functor with application, but without pure
+export type ApplyBase = Functor & {
+    '<*>'<A, B>(f: MinBox1<FunctionArrow<A, B>>, fa: MinBox1<A>): MinBox1<B>
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, C>, fa: MinBox1<A>, fb: MinBox1<B>): MinBox1<C>
+}
+
+export type Apply = ApplyBase & {
+    '*>'<A, B>(fa: MinBox1<A>, fb: MinBox1<B>): MinBox1<B>
+    '<*'<A, B>(fa: MinBox1<A>, fb: MinBox1<B>): MinBox1<A>
+    '<**>'<A, B>(fa: MinBox1<A>, f: MinBox1<FunctionArrow<A, B>>): MinBox1<B>
+}
+
+export type BaseImplementation = Partial<Pick<ApplyBase, '<*>' | 'liftA2'>> &
+    (Pick<ApplyBase, '<*>'> | Pick<ApplyBase, 'liftA2'>)
+
+const extensions = (base: ApplyBase) => ({
+    // u *> v = (id <$ u) <*> v
+    '*>': <A, B>(fa: MinBox1<A>, fb: MinBox1<B>): MinBox1<B> => base['<*>'](base['<$'](id, fa), fb),
+
+    // u <* v = liftA2 const u v
+    '<*': <A, B>(fa: MinBox1<A>, fb: MinBox1<B>): MinBox1<A> => base.liftA2($const, fa, fb),
+
+    // (<**>) = liftA2 (\a f -> f a)
+    '<**>': <A, B>(fa: MinBox1<A>, f: MinBox1<FunctionArrow<A, B>>): MinBox1<B> =>
+        base.liftA2(
+            <A, C>(a: A) =>
+                (b: (_: A) => C) =>
+                    b(a) as C,
+            fa,
+            f,
+        ),
+})
+
+export const apply = (base: BaseImplementation, fBase: Functor): Apply => {
+    const star = base['<*>']
+    const lift = base.liftA2
+
+    const applyBase = {
+        ...fBase,
+        ...base,
+        '<*>': star,
+        liftA2: lift,
+    } as ApplyBase
+
+    if (star && !lift) {
+        // liftA2 f x y = f <$> x <*> y
+        applyBase.liftA2 = <A, B, C>(f: FunctionArrow2<A, B, C>, fa: MinBox1<A>, fb: MinBox1<B>): MinBox1<C> =>
+            star(fBase['<$>'](f, fa), fb)
+    }
+
+    if (!star && lift) {
+        // (<*>) = liftA2 id
+        applyBase['<*>'] = <A, B>(f: MinBox1<FunctionArrow<A, B>>, fa: MinBox1<A>): MinBox1<B> => lift(id, f, fa)
+    }
+
+    return {
+        ...applyBase,
+        ...extensions(applyBase),
+    }
+}
+
+// Helper: derive Apply from an existing Applicative (drops pure)
+export const fromApplicative = (app: Applicative): Apply => apply({ '<*>': app['<*>'], liftA2: app.liftA2 }, app)
+
+// Helper: construct an Applicative from an Apply and a `pure`
+export const toApplicative = (ap: Apply, pure: <A>(a: NonNullable<A>) => MinBox1<A>): Applicative =>
+    createApplicative({ pure, '<*>': ap['<*>'], liftA2: ap.liftA2 }, ap)

--- a/src/extra/promise/apply.ts
+++ b/src/extra/promise/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'extra/promise/applicative'
+
+export const apply = fromApplicative(applicative)

--- a/src/ghc/base/function-arrow/apply.ts
+++ b/src/ghc/base/function-arrow/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'ghc/base/function-arrow/applicative'
+
+export const apply = <T>() => fromApplicative(applicative<T>())

--- a/src/ghc/base/list/apply.ts
+++ b/src/ghc/base/list/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'ghc/base/list/applicative'
+
+export const apply = fromApplicative(applicative)

--- a/src/ghc/base/maybe/apply.ts
+++ b/src/ghc/base/maybe/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'ghc/base/maybe/applicative'
+
+export const apply = fromApplicative(applicative)

--- a/src/ghc/base/non-empty/apply.ts
+++ b/src/ghc/base/non-empty/apply.ts
@@ -1,0 +1,4 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'ghc/base/non-empty/applicative'
+
+export const apply = fromApplicative(applicative)

--- a/src/ghc/base/tuple/tuple2-apply.ts
+++ b/src/ghc/base/tuple/tuple2-apply.ts
@@ -1,0 +1,5 @@
+import { fromApplicative } from 'data/functor/apply'
+import { applicative } from 'ghc/base/tuple/tuple2-applicative'
+import { Monoid } from 'ghc/base/monoid'
+
+export const apply = <T>(m: Monoid<T>) => fromApplicative(applicative<T>(m))

--- a/test/control/reader/apply.test.ts
+++ b/test/control/reader/apply.test.ts
@@ -1,0 +1,30 @@
+import tap from 'tap'
+import { apply } from 'control/reader/apply'
+import { reader, ReaderBox } from 'control/reader/reader'
+
+const run = <A>(r: ReaderBox<string, A>, env: string) => r.runReader(env)
+
+tap.test('Reader Apply', async (t) => {
+    const A = apply<string>()
+
+    const rf = reader((env: string) => (x: number) => x + env.length)
+    const ra = reader((env: string) => env.length)
+
+    const r = A['<*>'](rf, ra) as ReaderBox<string, number>
+    t.equal(run(r, 'abc'), 6)
+
+    const rThen = A['*>'](
+        ra,
+        reader((env: string) => env.toUpperCase()),
+    ) as ReaderBox<string, string>
+    t.equal(run(rThen, 'ab'), 'AB')
+
+    const rLeft = A['<*'](
+        ra,
+        reader((env: string) => env.toUpperCase()),
+    ) as ReaderBox<string, number>
+    t.equal(run(rLeft, 'ab'), 2)
+
+    const rFlip = A['<**>'](ra, rf) as ReaderBox<string, number>
+    t.equal(run(rFlip, 'a'), 2)
+})

--- a/test/control/state/apply.test.ts
+++ b/test/control/state/apply.test.ts
@@ -1,0 +1,36 @@
+import tap from 'tap'
+import { apply } from 'control/state/apply'
+import { state, runState, StateBox } from 'control/state/state'
+import { tuple2 } from 'ghc/base/tuple/tuple'
+
+tap.test('State Apply', async (t) => {
+    const A = apply<number>()
+
+    const sf = state<number, (x: number) => number>((s) => tuple2((x: number) => x + s, s + 1))
+    const sa = state<number, number>((s) => tuple2(s * 2, s + 1))
+
+    const r = A['<*>'](sf, sa) as StateBox<number, number>
+    const [v, s] = runState(r as StateBox<number, number>, 3)
+    t.equal(v, 11)
+    t.equal(s, 5)
+
+    const rThen = A['*>'](
+        sa,
+        state<number, number>((s: number) => tuple2(s + 10, s + 1)),
+    )
+    const [v2, s2] = runState(rThen as StateBox<number, number>, 1)
+    t.equal(v2, 12)
+    t.equal(s2, 3)
+
+    const rLeft = A['<*'](
+        sa,
+        state<number, number>((s: number) => tuple2(s + 10, s + 1)),
+    )
+    const [v3, s3] = runState(rLeft as StateBox<number, number>, 1)
+    t.equal(v3, 2)
+    t.equal(s3, 3)
+
+    const rFlip = A['<**>'](sa, sf)
+    const [v4] = runState(rFlip as StateBox<number, number>, 2)
+    t.equal(v4, 7)
+})

--- a/test/control/writer/apply.test.ts
+++ b/test/control/writer/apply.test.ts
@@ -1,0 +1,48 @@
+import tap from 'tap'
+import { apply } from 'control/writer/apply'
+import { writer, runWriter, WriterBox } from 'control/writer/writer'
+import { tuple2 } from 'ghc/base/tuple/tuple'
+import { monoid as listMonoid } from 'ghc/base/list/monoid'
+import { cons, nil, toArray, ListBox } from 'ghc/base/list/list'
+
+const createList = <T>(values: NonNullable<T>[]): ListBox<T> =>
+    values.reduceRight((acc, curr) => cons(curr)(acc), nil<T>())
+
+tap.test('Writer Apply', async (t) => {
+    const logMonoid = listMonoid<string>()
+    const A = apply(logMonoid)
+
+    const wf = writer(() => tuple2((x: number) => x + 1, createList(['a'])))
+    const wa = writer(() => tuple2(3, createList(['b'])))
+    const wApply = A['<*>'](
+        wf as WriterBox<ListBox<string>, (x: number) => number>,
+        wa as WriterBox<ListBox<string>, number>,
+    ) as WriterBox<ListBox<string>, number>
+    const [v, l] = runWriter(wApply)
+    t.equal(v, 4)
+    t.same(toArray(l as ListBox<string>), ['a', 'b'])
+
+    const wThen = A['*>'](
+        wa as WriterBox<ListBox<string>, number>,
+        writer(() => tuple2(5, createList(['c']))) as WriterBox<ListBox<string>, number>,
+    ) as WriterBox<ListBox<string>, number>
+    const [v2, l2] = runWriter(wThen)
+    t.equal(v2, 5)
+    t.same(toArray(l2 as ListBox<string>), ['b', 'c'])
+
+    const wLeft = A['<*'](
+        wa as WriterBox<ListBox<string>, number>,
+        writer(() => tuple2(5, createList(['c']))) as WriterBox<ListBox<string>, number>,
+    ) as WriterBox<ListBox<string>, number>
+    const [v3, l3] = runWriter(wLeft)
+    t.equal(v3, 3)
+    t.same(toArray(l3 as ListBox<string>), ['b', 'c'])
+
+    const wFlip = A['<**>'](
+        wa as WriterBox<ListBox<string>, number>,
+        wf as WriterBox<ListBox<string>, (x: number) => number>,
+    ) as WriterBox<ListBox<string>, number>
+    const [v4, l4] = runWriter(wFlip)
+    t.equal(v4, 4)
+    t.same(toArray(l4 as ListBox<string>), ['b', 'a'])
+})

--- a/test/data/either/apply.test.ts
+++ b/test/data/either/apply.test.ts
@@ -1,0 +1,21 @@
+import tap from 'tap'
+import { apply } from 'data/either/apply'
+import { left, right, $case, EitherBox } from 'data/either/either'
+
+const inspect = <L, R>(e: EitherBox<L, R>) => $case<L, R, string>({ left: (l) => `L:${l}`, right: (r) => `R:${r}` })(e)
+
+tap.test('Either Apply', async (t) => {
+    const A = apply<string>()
+
+    const rf = right<string, (x: number) => number>((x) => x + 1)
+    const ra = right<string, number>(2)
+    const le = left<string, number>('e')
+
+    t.equal(inspect(A['<*>'](rf, ra) as EitherBox<string, number>), 'R:3')
+    t.equal(inspect(A['<*>'](rf, le) as EitherBox<string, number>), 'L:e')
+    t.equal(inspect(A['<*>'](left('e'), ra) as EitherBox<string, number>), 'L:e')
+
+    t.equal(inspect(A['*>'](ra, right<string, number>(5)) as EitherBox<string, number>), 'R:5')
+    t.equal(inspect(A['<*'](ra, right<string, number>(5)) as EitherBox<string, number>), 'R:2')
+    t.equal(inspect(A['<**>'](ra, rf) as EitherBox<string, number>), 'R:3')
+})

--- a/test/data/functor/apply.test.ts
+++ b/test/data/functor/apply.test.ts
@@ -1,0 +1,98 @@
+import tap from 'tap'
+import { apply as createApply, toApplicative, fromApplicative } from 'data/functor/apply'
+import { dot } from 'ghc/base/functions'
+import { functor as listFunctor } from 'ghc/base/list/functor'
+import { applicative as listApplicative } from 'ghc/base/list/applicative'
+import { cons, nil, head, ListBox } from 'ghc/base/list/list'
+import { comp } from 'ghc/base/list/comprehension'
+
+tap.test('Apply (factory + laws)', async (t) => {
+    t.test('derive liftA2 from <*>', async (t) => {
+        const base = {
+            '<*>': <A, B>(f: ListBox<(_: A) => B>, fa: ListBox<A>): ListBox<B> => comp((fn, a) => fn(a), [f, fa]),
+        }
+        const A = createApply(base, listFunctor)
+
+        const fa = cons<number>(2)(nil<number>())
+        const fb = cons<number>(3)(nil<number>())
+        const sum2 = (x: number) => (y: number) => x + y
+
+        const r1 = A['<*>'](cons<(x: number) => number>((x) => x + 5)(nil()), fa) as ListBox<number>
+        t.equal(head(r1), 7)
+
+        const r2 = A.liftA2(sum2, fa, fb) as ListBox<number>
+        t.equal(head(r2), 5)
+
+        const rThen = A['*>'](fa, fb) as ListBox<number>
+        t.equal(head(rThen), 3)
+
+        const rLeft = A['<*'](fa, fb) as ListBox<number>
+        t.equal(head(rLeft), 2)
+
+        const rFlip = A['<**>'](fa, cons<(x: number) => number>((x) => x * 10)(nil())) as ListBox<number>
+        t.equal(head(rFlip), 20)
+    })
+
+    t.test('derive <*> from liftA2', async (t) => {
+        const base = {
+            liftA2: <A, B, C>(f: (_: A) => (_: B) => C, fa: ListBox<A>, fb: ListBox<B>): ListBox<C> =>
+                comp((a, b) => f(a)(b), [fa, fb]),
+        }
+        const A = createApply(base, listFunctor)
+
+        const fa = cons<number>(4)(nil<number>())
+        const r1 = A['<*>'](cons<(x: number) => number>((x) => x - 1)(nil()), fa) as ListBox<number>
+        t.equal(head(r1), 3)
+    })
+
+    t.test('Apply associativity (composition) law', async (t) => {
+        const base = {
+            '<*>': <A, B>(f: ListBox<(_: A) => B>, fa: ListBox<A>): ListBox<B> => comp((fn, a) => fn(a), [f, fa]),
+        }
+        const A = createApply(base, listFunctor)
+
+        // u :: f (b -> c), v :: f (a -> b), w :: f a
+        const u = cons<(b: number) => number>((y) => y + 10)(nil())
+        const v = cons<(a: number) => number>((x) => x * 2)(nil())
+        const w = cons<number>(3)(nil<number>())
+
+        const left = A['<*>'](
+            A['<*>'](listFunctor['<$>'](dot as unknown as (g: (_: number) => number) => (_: number) => number, u), v),
+            w,
+        ) as ListBox<number>
+        const right = A['<*>'](u, A['<*>'](v, w)) as ListBox<number>
+
+        t.equal(head(left), head(right))
+        t.equal(head(right), 16)
+    })
+
+    t.test('toApplicative (Apply + pure) yields Applicative', async (t) => {
+        const base = {
+            '<*>': <A, B>(f: ListBox<(_: A) => B>, fa: ListBox<A>): ListBox<B> => comp((fn, a) => fn(a), [f, fa]),
+        }
+        const A = createApply(base, listFunctor)
+        const pure = <A>(a: NonNullable<A>) => cons<NonNullable<A>>(a)(nil<NonNullable<A>>())
+        const App = toApplicative(A, pure)
+
+        const v = cons<number>(7)(nil<number>())
+        const pureId = App.pure((x: number) => x)
+        const result = App['<*>'](pureId, v) as ListBox<number>
+
+        t.equal(head(result), 7)
+    })
+
+    t.test('fromApplicative (drops pure) yields Apply', async (t) => {
+        const App = listApplicative
+        const Ap = fromApplicative(App)
+
+        const fa = cons<number>(2)(nil<number>())
+        const fb = cons<number>(5)(nil<number>())
+        const plus1 = cons<(x: number) => number>((x) => x + 1)(nil())
+
+        const r1 = Ap['<*>'](plus1, fa) as ListBox<number>
+        t.equal(head(r1), 3)
+
+        const r2 = Ap.liftA2((x: number) => (y: number) => x + y, fa, fb) as ListBox<number>
+        t.equal(head(r2), 7)
+    })
+})

--- a/test/extra/promise/apply.test.ts
+++ b/test/extra/promise/apply.test.ts
@@ -1,0 +1,25 @@
+import tap from 'tap'
+import { apply } from 'extra/promise/apply'
+import { PromiseBox } from 'extra/promise/promise'
+
+tap.test('Promise Apply', async (t) => {
+    const A = apply
+
+    const f = Promise.resolve((x: number) => x + 1) as PromiseBox<(x: number) => number>
+    const a = Promise.resolve(2) as PromiseBox<number>
+
+    const r = await A['<*>'](f, a)
+    t.equal(r, 3)
+
+    const rThen = await A['*>'](Promise.resolve(1) as PromiseBox<number>, Promise.resolve(5) as PromiseBox<number>)
+    t.equal(rThen, 5)
+
+    const rLeft = await A['<*'](Promise.resolve(1) as PromiseBox<number>, Promise.resolve(5) as PromiseBox<number>)
+    t.equal(rLeft, 1)
+
+    const rFlip = await A['<**>'](
+        Promise.resolve(2) as PromiseBox<number>,
+        Promise.resolve((x: number) => x + 3) as PromiseBox<(x: number) => number>,
+    )
+    t.equal(rFlip, 5)
+})

--- a/test/ghc/base/function-arrow/apply.test.ts
+++ b/test/ghc/base/function-arrow/apply.test.ts
@@ -1,0 +1,31 @@
+import tap from 'tap'
+import { apply } from 'ghc/base/function-arrow/apply'
+import { withKind, FunctionArrowBox } from 'ghc/prim/function-arrow'
+
+tap.test('Function Arrow Apply', async (t) => {
+    const A = apply<number>()
+
+    const f = withKind((n: number) => (x: string) => x + '!' + n)
+    const v = withKind((n: number) => n.toString())
+
+    const res = A['<*>'](f, v) as FunctionArrowBox<number, string>
+    t.equal(res(3), '3!3')
+
+    const thenRes = A['*>'](
+        withKind((_: number) => 1),
+        withKind((_: number) => 2),
+    ) as FunctionArrowBox<number, number>
+    t.equal(thenRes(0), 2)
+
+    const leftRes = A['<*'](
+        withKind((_: number) => 1),
+        withKind((_: number) => 2),
+    ) as FunctionArrowBox<number, number>
+    t.equal(leftRes(0), 1)
+
+    const flipRes = A['<**>'](
+        withKind((_: number) => 5),
+        withKind((_: number) => (x: number) => x + 1),
+    ) as FunctionArrowBox<number, number>
+    t.equal(flipRes(0), 6)
+})

--- a/test/ghc/base/list/apply.test.ts
+++ b/test/ghc/base/list/apply.test.ts
@@ -1,0 +1,22 @@
+import tap from 'tap'
+import { apply } from 'ghc/base/list/apply'
+import { cons, nil, head, ListBox } from 'ghc/base/list/list'
+
+tap.test('List Apply', async (t) => {
+    const A = apply
+
+    const fa = cons<number>(2)(nil<number>())
+    const fb = cons<number>(3)(nil<number>())
+
+    const rApply = A['<*>'](cons<(x: number) => number>((x) => x + 1)(nil()), fa) as ListBox<number>
+    t.equal(head(rApply), 3)
+
+    const rThen = A['*>'](fa, fb) as ListBox<number>
+    t.equal(head(rThen), 3)
+
+    const rLeft = A['<*'](fa, fb) as ListBox<number>
+    t.equal(head(rLeft), 2)
+
+    const rFlip = A['<**>'](fa, cons<(x: number) => number>((x) => x * 10)(nil())) as ListBox<number>
+    t.equal(head(rFlip), 20)
+})

--- a/test/ghc/base/maybe/apply.test.ts
+++ b/test/ghc/base/maybe/apply.test.ts
@@ -1,0 +1,25 @@
+import tap from 'tap'
+import { apply } from 'ghc/base/maybe/apply'
+import { $case as maybeCase, just, nothing, MaybeBox } from 'ghc/base/maybe/maybe'
+
+const inspect = <T>(m: MaybeBox<T>) =>
+    maybeCase<T, string>({
+        nothing: () => 'N',
+        just: (x: T) => `J:${x}`,
+    })(m)
+
+tap.test('Maybe Apply', async (t) => {
+    const A = apply
+
+    const jf = just<(x: number) => number>((x) => x + 1)
+    const ja = just(2)
+    const nn = nothing<number>()
+
+    t.equal(inspect(A['<*>'](jf, ja) as MaybeBox<number>), 'J:3')
+    t.equal(inspect(A['<*>'](jf, nn) as MaybeBox<number>), 'N')
+    t.equal(inspect(A['<*>'](nothing(), ja) as MaybeBox<number>), 'N')
+
+    t.equal(inspect(A['*>'](ja, just(5)) as MaybeBox<number>), 'J:5')
+    t.equal(inspect(A['<*'](ja, just(5)) as MaybeBox<number>), 'J:2')
+    t.equal(inspect(A['<**>'](ja, jf) as MaybeBox<number>), 'J:3')
+})

--- a/test/ghc/base/non-empty/apply.test.ts
+++ b/test/ghc/base/non-empty/apply.test.ts
@@ -1,0 +1,23 @@
+import tap from 'tap'
+import { apply } from 'ghc/base/non-empty/apply'
+import { cons as neCons, toList, NonEmptyBox } from 'ghc/base/non-empty/list'
+import { nil, head } from 'ghc/base/list/list'
+
+tap.test('NonEmpty Apply', async (t) => {
+    const A = apply
+
+    const nf = neCons<(x: number) => number>((x) => x + 1)(nil())
+    const na = neCons<number>(2)(nil<number>())
+
+    const r = A['<*>'](nf, na) as NonEmptyBox<number>
+    t.equal(head(toList(r)), 3)
+
+    const rThen = A['*>'](na, neCons<number>(5)(nil<number>())) as NonEmptyBox<number>
+    t.equal(head(toList(rThen)), 5)
+
+    const rLeft = A['<*'](na, neCons<number>(5)(nil<number>())) as NonEmptyBox<number>
+    t.equal(head(toList(rLeft)), 2)
+
+    const rFlip = A['<**>'](na, nf) as NonEmptyBox<number>
+    t.equal(head(toList(rFlip)), 3)
+})

--- a/test/ghc/base/tuple/tuple2-apply.test.ts
+++ b/test/ghc/base/tuple/tuple2-apply.test.ts
@@ -1,0 +1,38 @@
+import tap from 'tap'
+import { apply } from 'ghc/base/tuple/tuple2-apply'
+import { monoid as unitMonoid } from 'ghc/base/tuple/unit-monoid'
+import { tuple2, fst, snd, Tuple2BoxT, UnitBox, unit } from 'ghc/base/tuple/tuple'
+
+tap.test('Tuple2 Apply', async (t) => {
+    const A = apply(unitMonoid)
+
+    const f = tuple2<UnitBox, (x: number) => number>(unit(), (x) => x + 1)
+    const a = tuple2<UnitBox, number>(unit(), 2)
+
+    const r = A['<*>'](f as Tuple2BoxT<UnitBox, (x: number) => number>, a as Tuple2BoxT<UnitBox, number>) as Tuple2BoxT<
+        UnitBox,
+        number
+    >
+    t.equal(snd(r), 3)
+
+    const rThen = A['*>'](
+        a as Tuple2BoxT<UnitBox, number>,
+        tuple2(unit(), 5) as Tuple2BoxT<UnitBox, number>,
+    ) as Tuple2BoxT<UnitBox, number>
+    t.equal(snd(rThen), 5)
+
+    const rLeft = A['<*'](
+        a as Tuple2BoxT<UnitBox, number>,
+        tuple2(unit(), 5) as Tuple2BoxT<UnitBox, number>,
+    ) as Tuple2BoxT<UnitBox, number>
+    t.equal(snd(rLeft), 2)
+
+    const rFlip = A['<**>'](
+        a as Tuple2BoxT<UnitBox, number>,
+        f as Tuple2BoxT<UnitBox, (x: number) => number>,
+    ) as Tuple2BoxT<UnitBox, number>
+    t.equal(snd(rFlip), 3)
+
+    // Compare structurally, not by reference
+    t.same(fst(A['<*>'](f, a) as Tuple2BoxT<UnitBox, number>), unit())
+})


### PR DESCRIPTION
1. Introduces Apply typeclass (Functor with application, without pure).
2. Adds helpers to convert between Apply and Applicative: fromApplicative: drop pure to get Apply, toApplicative: add pure to build Applicative
3. Implements Apply for all existing Applicative instances.
4. Adds comprehensive tests (usage + law) and updates README with Apply column and links.