### PR TITLE
MaybeT, Either T

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,25 @@ npm test
 - `✓` = available instance
 - `*` = requires the underlying value type to have the same instance
 
-| Type       | Functor | Apply | Applicative | Alternative | Monad | MonadPlus | Bifunctor | Comonad | ComonadApply | Foldable | Traversable | Semigroup | Monoid |
-| ---------- | :-----: | :---: | :---------: | :---------: | :---: | :-------: | :------: | :-----: | :----------: | :------: | :---------: | :-------: | :----: |
-| Maybe      | ✓       | ✓     | ✓           | ✓           | ✓     | ✓         |          |         |              | ✓        | ✓           | ✓*        | ✓*  |
-| Either e   | ✓       | ✓     | ✓           | ✓*          | ✓     | ✓*        | ✓        |         |              | ✓        | ✓           | ✓*        | ✓*  |
-| List       | ✓       | ✓     | ✓           | ✓           | ✓     | ✓         |          |         |              | ✓        | ✓           | ✓         | ✓  |
-| NonEmpty   | ✓       | ✓     | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓         |  |
-| Reader r   | ✓       | ✓     | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| Writer w   | ✓       | ✓*    | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| State s    | ✓       | ✓     | ✓           |             | ✓     |           |          |         |              |          |             |           |  |
-| (->) r     | ✓       | ✓     | ✓           |             | ✓     |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| Tuple2 a   | ✓       | ✓*    | ✓           |             | ✓     |           | ✓        | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
-| Promise    | ✓       | ✓     | ✓           |             | ✓     |           |          |         |              | ✓        |             | ✓*        | ✓*  |
-| Unit ()    |         |       |             |             |       |           |          |         |              |          |             | ✓         | ✓  |
-| ReaderT r m| ✓*      | ✓*    | ✓*          |             | ✓*    |           |          |         |              |          |             |           |    |
-| WriterT w m| ✓*      | ✓*    | ✓*          |             | ✓*    |           |          |         |              |          |             |           |    |
-| StateT s m | ✓*      | ✓*    | ✓*          |             | ✓*    |           |          |         |              |          |             |           |    |
+| Type       | Functor | Apply | Applicative | Alternative | Monad | MonadTrans | MonadPlus | Bifunctor | Comonad | ComonadApply | Foldable | Traversable | Semigroup | Monoid |
+| ---------- | :-----: | :---: | :---------: | :---------: | :---: | :--------: | :-------: | :------: | :-----: | :----------: | :------: | :---------: | :-------: | :----: |
+| Maybe      | ✓       | ✓     | ✓           | ✓           | ✓     |            | ✓         |          |         |              | ✓        | ✓           | ✓*        | ✓*  |
+| Either e   | ✓       | ✓     | ✓           | ✓*          | ✓     |            | ✓*        | ✓        |         |              | ✓        | ✓           | ✓*        | ✓*  |
+| List       | ✓       | ✓     | ✓           | ✓           | ✓     |            | ✓         |          |         |              | ✓        | ✓           | ✓         | ✓  |
+| NonEmpty   | ✓       | ✓     | ✓           |             | ✓     |            |           |          | ✓       | ✓            | ✓        | ✓           | ✓         |  |
+| Reader r   | ✓       | ✓     | ✓           |             | ✓     |            |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| Writer w   | ✓       | ✓*    | ✓           |             | ✓     |            |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| State s    | ✓       | ✓     | ✓           |             | ✓     |            |           |          |         |              |          |             |           |  |
+| (->) r     | ✓       | ✓     | ✓           |             | ✓     |            |           |          | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| Tuple2 a   | ✓       | ✓*    | ✓           |             | ✓     |            |           | ✓        | ✓       | ✓            | ✓        | ✓           | ✓*        | ✓*  |
+| Promise    | ✓       | ✓     | ✓           |             | ✓     |            |           |          |         |              | ✓        |             | ✓*        | ✓*  |
+| Unit ()    |         |       |             |             |       |            |           |          |         |              |          |             | ✓         | ✓  |
+| ReaderT r m| ✓*      | ✓*    | ✓*          |             | ✓*    |     ✓      |           |          |         |              |          |             |           |    |
+| WriterT w m| ✓*      | ✓*    | ✓*          |             | ✓*    |     ✓      |           |          |         |              |          |             |           |    |
+| StateT s m | ✓*      | ✓*    | ✓*          |             | ✓*    |     ✓      |           |          |         |              |          |             |           |    |
+| MaybeT m   | ✓*      | ✓*    | ✓*          |             | ✓*    |     ✓      |           |          |         |              |          |             |           |    |
+| EitherT e m| ✓*      | ✓*    | ✓*          |             | ✓*    |     ✓      |           |          |         |              |          |             |           |    |
+| ExceptT e m| ✓*      | ✓*    | ✓*          |             | ✓*    |     ✓      |           |          |         |              |          |             |           |    |
 
 ## References
 
@@ -67,6 +70,10 @@ npm test
 - [Alternative](src/control/alternative/alternative.ts)
 - [Monad](src/ghc/base/monad/monad.ts)
 - [MonadPlus](src/control/monad-plus/monad-plus.ts)
+- [MonadTrans](src/control/monad/trans/monad-trans.ts)
+- [MaybeT](src/control/monad/trans/maybe/monad.ts)
+- [EitherT](src/control/monad/trans/either/monad.ts)
+- [ExceptT](src/control/monad/trans/except/monad.ts)
 - [Comonad](src/control/comonad.ts)
 - [ComonadApply](src/control/comonad-apply.ts)
 - [Foldable](src/data/foldable.ts)

--- a/src/control/alternative/alternative.ts
+++ b/src/control/alternative/alternative.ts
@@ -1,8 +1,9 @@
 import { MinBox1 } from 'data/kind'
 import { Applicative } from 'ghc/base/applicative'
-import { ListBox, cons, nil, $null } from 'ghc/base/list/list'
+import { ListBox, cons, nil, $null, concat as listConcat, toArray as listToArray } from 'ghc/base/list/list'
 
-/* c8 ignore start */
+// Upper bound to stop list enumerations from trying to realize an infinite Apply expansion.
+const LIST_SEQUENCE_LIMIT = 256
 
 export type AlternativeBase = {
     empty<A>(): MinBox1<A>
@@ -16,6 +17,100 @@ export type Alternative = Applicative &
     }
 
 export type BaseImplementation = Pick<AlternativeBase, 'empty' | '<|>'>
+
+// Wraps recursive Alternative branches so the right-hand side is evaluated only on demand.
+const defer = <A>(thunk: () => MinBox1<A>): MinBox1<A> => {
+    let cached: MinBox1<A> | null = null
+
+    const ensure = (): MinBox1<A> => {
+        if (cached === null) {
+            cached = thunk()
+
+            if (cached && typeof cached === 'object') {
+                for (const key of Object.keys(cached as object)) {
+                    if (!(key in wrapper)) {
+                        Object.defineProperty(wrapper, key, {
+                            configurable: true,
+                            get: () => (ensure() as Record<string, unknown>)[key],
+                            set: (value: unknown) => {
+                                ;(ensure() as Record<string, unknown>)[key] = value
+                            },
+                        })
+                    }
+                }
+            }
+        }
+
+        return cached
+    }
+
+    const wrapper = (() => (ensure() as unknown as () => unknown)()) as unknown as MinBox1<A>
+
+    Object.defineProperty(wrapper, 'kind', {
+        configurable: true,
+        get() {
+            return (ensure() as { kind: unknown }).kind
+        },
+        set(value: unknown) {
+            ;(ensure() as { kind: unknown }).kind = value
+        },
+    })
+
+    return wrapper
+}
+
+// Detects List-style thunks so we can switch to breadth-first enumeration instead of lazy binds.
+const isListLike = <A>(fa: MinBox1<A>): fa is ListBox<A> => {
+    if (typeof fa !== 'function') {
+        return false
+    }
+
+    try {
+        const value = (fa as unknown as () => unknown)()
+        if (Array.isArray(value)) {
+            return true
+        }
+
+        return value != null && typeof value === 'object' && 'head' in value && 'tail' in value
+    } catch {
+        return false
+    }
+}
+
+const buildListFromArray = <A>(values: A[]): ListBox<A> =>
+    values.reduceRight((acc, value) => cons(value as NonNullable<A>)(acc), nil<A>())
+
+const listSome = <A>(fa: ListBox<A>): ListBox<ListBox<A>> => {
+    if ($null(fa)) {
+        return nil()
+    }
+
+    const choices = listToArray(fa)
+
+    const queue: A[][] = choices.map((choice) => [choice as NonNullable<A>])
+    const sequences: ListBox<A>[] = []
+
+    while (queue.length > 0 && sequences.length < LIST_SEQUENCE_LIMIT) {
+        const current = queue.shift() as A[]
+        sequences.push(buildListFromArray(current))
+
+        for (const choice of choices) {
+            if (sequences.length + queue.length >= LIST_SEQUENCE_LIMIT) {
+                break
+            }
+
+            queue.push([...current, choice as NonNullable<A>])
+        }
+    }
+
+    return sequences.reduceRight((acc, seq) => cons(seq)(acc), nil<ListBox<A>>())
+}
+
+const listMany = <A>(fa: ListBox<A>): ListBox<ListBox<A>> => {
+    const singletonEmpty = cons<ListBox<A>>(nil<A>())(nil<ListBox<A>>())
+    const some = listSome(fa) as unknown as ListBox<ListBox<A>>
+    return listConcat(some, singletonEmpty)
+}
 
 export const alternative = (base: BaseImplementation, applicative: Applicative): Alternative => {
     const replicate = <A>(n: number, fa: MinBox1<A>): MinBox1<ListBox<A>> => {
@@ -31,16 +126,30 @@ export const alternative = (base: BaseImplementation, applicative: Applicative):
     }
 
     const some = <A>(fa: MinBox1<A>): MinBox1<ListBox<A>> => {
-        if ($null(fa as unknown as ListBox<A>)) {
-            return base.empty<ListBox<A>>()
+        if (isListLike(fa)) {
+            if ($null(fa as unknown as ListBox<A>)) {
+                return base.empty<ListBox<A>>()
+            }
+
+            return listSome(fa)
         }
 
-        const build = (n: number): MinBox1<ListBox<A>> => base['<|>'](replicate(n, fa), build(n + 1))
+        const build = (n: number): MinBox1<ListBox<A>> =>
+            base['<|>'](
+                replicate(n, fa),
+                defer(() => build(n + 1)),
+            )
 
         return build(1)
     }
 
-    const many = <A>(fa: MinBox1<A>): MinBox1<ListBox<A>> => base['<|>'](some(fa), applicative.pure(nil()))
+    const many = <A>(fa: MinBox1<A>): MinBox1<ListBox<A>> => {
+        if (isListLike(fa)) {
+            return listMany(fa)
+        }
+
+        return base['<|>'](some(fa), applicative.pure(nil()))
+    }
 
     return {
         ...applicative,
@@ -50,4 +159,8 @@ export const alternative = (base: BaseImplementation, applicative: Applicative):
     }
 }
 
-/* c8 ignore stop */
+// Expose internals for white-box tests that exercise the lazy wrapper and detection paths.
+export const __testing = {
+    defer,
+    isListLike,
+}

--- a/src/control/monad/trans/either/applicative.ts
+++ b/src/control/monad/trans/either/applicative.ts
@@ -1,0 +1,63 @@
+import { applicative as createApplicative, Applicative, BaseImplementation } from 'ghc/base/applicative'
+import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import type { Monad } from 'ghc/base/monad/monad'
+import { EitherBox, right } from 'data/either/either'
+import { applicative as eitherApplicative } from 'data/either/applicative'
+import { EitherTBox, eitherT } from './either-t'
+import { functor as createFunctor } from './functor'
+
+export interface EitherTApplicative<E> extends Applicative {
+    pure<A>(a: A): EitherTBox<E, A>
+
+    '<*>'<A, B>(f: EitherTBox<E, FunctionArrow<A, B>>, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, C>, fa: EitherTBox<E, A>, fb: EitherTBox<E, B>): EitherTBox<E, C>
+
+    '*>'<A, B>(fa: EitherTBox<E, A>, fb: EitherTBox<E, B>): EitherTBox<E, B>
+
+    '<*'<A, B>(fa: EitherTBox<E, A>, fb: EitherTBox<E, B>): EitherTBox<E, A>
+
+    '<**>'<A, B>(fa: EitherTBox<E, A>, f: EitherTBox<E, FunctionArrow<A, B>>): EitherTBox<E, B>
+
+    fmap<A, B>(f: (a: A) => B, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    '<$'<A, B>(a: A, fb: EitherTBox<E, B>): EitherTBox<E, A>
+
+    '$>'<A, B>(fa: EitherTBox<E, A>, b: B): EitherTBox<E, B>
+
+    '<&>'<A, B>(fa: EitherTBox<E, A>, f: (a: A) => B): EitherTBox<E, B>
+
+    void<A>(fa: EitherTBox<E, A>): EitherTBox<E, []>
+}
+
+const baseImpl = <E>(m: Monad): BaseImplementation => ({
+    pure: <A>(a: NonNullable<A>): EitherTBox<E, A> => eitherT(() => m.pure(right(a) as EitherBox<E, A>)),
+
+    '<*>': <A, B>(f: EitherTBox<E, FunctionArrow<A, B>>, fa: EitherTBox<E, A>): EitherTBox<E, B> =>
+        eitherT(() =>
+            m['<*>'](
+                m['<$>'](
+                    (mf: EitherBox<E, FunctionArrow<A, B>>) => (ma: EitherBox<E, A>) =>
+                        eitherApplicative<E>()['<*>'](mf, ma) as EitherBox<E, B>,
+                    f.runEitherT(),
+                ),
+                fa.runEitherT(),
+            ),
+        ),
+
+    liftA2: <A, B, C>(f: FunctionArrow2<A, B, C>, fa: EitherTBox<E, A>, fb: EitherTBox<E, B>): EitherTBox<E, C> =>
+        eitherT(() =>
+            m.liftA2(
+                (ma: EitherBox<E, A>) => (mb: EitherBox<E, B>) => eitherApplicative<E>().liftA2(f, ma, mb),
+                fa.runEitherT(),
+                fb.runEitherT(),
+            ),
+        ),
+})
+
+export const applicative = <E>(m: Monad): EitherTApplicative<E> => {
+    const functor = createFunctor<E>(m)
+    return createApplicative(baseImpl<E>(m), functor) as EitherTApplicative<E>
+}

--- a/src/control/monad/trans/either/either-t.ts
+++ b/src/control/monad/trans/either/either-t.ts
@@ -1,0 +1,23 @@
+import { Box2, MinBox0, MinBox1, Type } from 'data/kind'
+import type { Monad } from 'ghc/base/monad/monad'
+import { EitherBox, right } from 'data/either/either'
+
+export interface EitherT<E, A> {
+    readonly runEitherT: () => MinBox1<EitherBox<E, A>>
+}
+
+export type EitherTBox<E, A> = EitherT<E, A> & Box2<E, A>
+
+export type EitherTMinBox<E, A> = EitherT<E, MinBox0<A>> & Box2<E, MinBox0<A>>
+
+export const eitherT = <E, A>(fn: () => MinBox1<EitherBox<E, A>>): EitherTBox<E, A> => ({
+    runEitherT: fn,
+    // Binary placeholder for kind annotation
+    kind: (_: '*') => (_: '*') => '*' as Type,
+})
+
+export const runEitherT = <E, A>(ma: EitherT<E, A>): MinBox1<EitherBox<E, A>> => ma.runEitherT()
+
+// lift :: Monad m => m a -> EitherT e m a
+export const lift = <E, A>(m: Monad, ma: MinBox1<A>): EitherTBox<E, A> =>
+    eitherT(() => m['<$>']((a: A) => right<E, A>(a as NonNullable<A>) as EitherBox<E, A>, ma))

--- a/src/control/monad/trans/either/functor.ts
+++ b/src/control/monad/trans/either/functor.ts
@@ -1,0 +1,34 @@
+import { Functor, functor as createFunctor, FunctorBase } from 'ghc/base/functor'
+import type { Monad } from 'ghc/base/monad/monad'
+import type { MinBox1 } from 'data/kind'
+import { EitherBox } from 'data/either/either'
+import { functor as eitherFunctor } from 'data/either/functor'
+import { EitherTBox, eitherT } from './either-t'
+
+export interface EitherTFunctor<E> extends Functor {
+    fmap<A, B>(f: (a: A) => B, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    '<$'<A, B>(a: A, fb: EitherTBox<E, B>): EitherTBox<E, A>
+
+    '$>'<A, B>(fa: EitherTBox<E, A>, b: B): EitherTBox<E, B>
+
+    '<&>'<A, B>(fa: EitherTBox<E, A>, f: (a: A) => B): EitherTBox<E, B>
+
+    void<A>(fa: EitherTBox<E, A>): EitherTBox<E, []>
+}
+
+const base = <E>(m: Monad): FunctorBase => ({
+    fmap: <A, B>(f: (a: A) => B, fa: EitherTBox<E, A>): EitherTBox<E, B> =>
+        eitherT(
+            () =>
+                m['<$>'](
+                    (mb: EitherBox<E, A>) =>
+                        eitherFunctor<E>().fmap(f as (a: A) => B, mb) as unknown as EitherBox<E, B>,
+                    fa.runEitherT(),
+                ) as unknown as MinBox1<EitherBox<E, B>>,
+        ),
+})
+
+export const functor = <E>(m: Monad): EitherTFunctor<E> => createFunctor(base<E>(m)) as EitherTFunctor<E>

--- a/src/control/monad/trans/either/monad.ts
+++ b/src/control/monad/trans/either/monad.ts
@@ -1,0 +1,57 @@
+import { Monad, monad as createMonad } from 'ghc/base/monad/monad'
+import { applicative as createApplicative } from './applicative'
+import { EitherTBox, eitherT } from './either-t'
+import { EitherBox, $case, left } from 'data/either/either'
+import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+
+export interface EitherTMonad<E> extends Monad {
+    '>>='<A, B>(ma: EitherTBox<E, A>, f: FunctionArrow<A, EitherTBox<E, B>>): EitherTBox<E, B>
+
+    '>>'<A, B>(ma: EitherTBox<E, A>, mb: EitherTBox<E, B>): EitherTBox<E, B>
+
+    return<A>(a: NonNullable<A>): EitherTBox<E, A>
+
+    pure<A>(a: NonNullable<A>): EitherTBox<E, A>
+
+    '<*>'<A, B>(f: EitherTBox<E, FunctionArrow<A, B>>, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, C>, fa: EitherTBox<E, A>, fb: EitherTBox<E, B>): EitherTBox<E, C>
+
+    '*>'<A, B>(fa: EitherTBox<E, A>, fb: EitherTBox<E, B>): EitherTBox<E, B>
+
+    '<*'<A, B>(fa: EitherTBox<E, A>, fb: EitherTBox<E, B>): EitherTBox<E, A>
+
+    '<**>'<A, B>(fa: EitherTBox<E, A>, f: EitherTBox<E, FunctionArrow<A, B>>): EitherTBox<E, B>
+
+    fmap<A, B>(f: (a: A) => B, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: EitherTBox<E, A>): EitherTBox<E, B>
+
+    '<$'<A, B>(a: A, fb: EitherTBox<E, B>): EitherTBox<E, A>
+
+    '$>'<A, B>(fa: EitherTBox<E, A>, b: B): EitherTBox<E, B>
+
+    '<&>'<A, B>(fa: EitherTBox<E, A>, f: (a: A) => B): EitherTBox<E, B>
+
+    void<A>(fa: EitherTBox<E, A>): EitherTBox<E, []>
+}
+
+const baseImplementation = <E>(m: Monad) => ({
+    '>>=': <A, B>(ma: EitherTBox<E, A>, f: FunctionArrow<A, EitherTBox<E, B>>): EitherTBox<E, B> =>
+        eitherT(() =>
+            m['>>='](
+                ma.runEitherT(),
+                (eb: EitherBox<E, A>): ReturnType<typeof m.return> =>
+                    $case<E, A, ReturnType<typeof m.return>>({
+                        left: (e: E) => m.pure(left<E, B>(e as NonNullable<E>) as EitherBox<E, B>),
+                        right: (x: A) => f(x).runEitherT(),
+                    })(eb),
+            ),
+        ),
+})
+
+export const monad = <E>(m: Monad): EitherTMonad<E> => {
+    const base = baseImplementation<E>(m)
+    const app = createApplicative<E>(m)
+    return createMonad(base, app) as EitherTMonad<E>
+}

--- a/src/control/monad/trans/except/applicative.ts
+++ b/src/control/monad/trans/except/applicative.ts
@@ -1,0 +1,6 @@
+import type { Monad } from 'ghc/base/monad/monad'
+import { applicative as eitherTApplicative } from '../either/applicative'
+import type { EitherTApplicative } from '../either/applicative'
+
+export type ExceptTApplicative<E> = EitherTApplicative<E>
+export const applicative = <E>(m: Monad) => eitherTApplicative<E>(m)

--- a/src/control/monad/trans/except/except-t.ts
+++ b/src/control/monad/trans/except/except-t.ts
@@ -1,0 +1,11 @@
+import { EitherTBox, eitherT, runEitherT, lift as liftEitherT } from '../either/either-t'
+import type { Monad } from 'ghc/base/monad/monad'
+import type { MinBox1 } from 'data/kind'
+
+// ExceptT e m a is a thin alias over EitherT e m a
+export type ExceptT<E, A> = EitherTBox<E, A>
+export type ExceptTBox<E, A> = EitherTBox<E, A>
+
+export const exceptT = eitherT
+export const runExceptT = runEitherT
+export const lift = <E, A>(m: Monad, ma: MinBox1<A>): ExceptTBox<E, A> => liftEitherT<E, A>(m, ma)

--- a/src/control/monad/trans/except/functor.ts
+++ b/src/control/monad/trans/except/functor.ts
@@ -1,0 +1,6 @@
+import type { Monad } from 'ghc/base/monad/monad'
+import { functor as eitherTFunctor } from '../either/functor'
+import type { EitherTFunctor } from '../either/functor'
+
+export type ExceptTFunctor<E> = EitherTFunctor<E>
+export const functor = <E>(m: Monad) => eitherTFunctor<E>(m)

--- a/src/control/monad/trans/except/monad.ts
+++ b/src/control/monad/trans/except/monad.ts
@@ -1,0 +1,6 @@
+import type { Monad } from 'ghc/base/monad/monad'
+import { monad as eitherTMonad } from '../either/monad'
+import type { EitherTMonad } from '../either/monad'
+
+export type ExceptTMonad<E> = EitherTMonad<E>
+export const monad = <E>(m: Monad) => eitherTMonad<E>(m)

--- a/src/control/monad/trans/maybe/applicative.ts
+++ b/src/control/monad/trans/maybe/applicative.ts
@@ -1,0 +1,63 @@
+import { applicative as createApplicative, Applicative, BaseImplementation } from 'ghc/base/applicative'
+import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+import type { Monad } from 'ghc/base/monad/monad'
+import { MaybeBox, just } from 'ghc/base/maybe/maybe'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { MaybeTBox, maybeT } from './maybe-t'
+import { functor as createFunctor } from './functor'
+
+export interface MaybeTApplicative extends Applicative {
+    pure<A>(a: A): MaybeTBox<A>
+
+    '<*>'<A, B>(f: MaybeTBox<FunctionArrow<A, B>>, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, NonNullable<C>>, fa: MaybeTBox<A>, fb: MaybeTBox<B>): MaybeTBox<C>
+
+    '*>'<A, B>(fa: MaybeTBox<A>, fb: MaybeTBox<B>): MaybeTBox<B>
+
+    '<*'<A, B>(fa: MaybeTBox<A>, fb: MaybeTBox<B>): MaybeTBox<A>
+
+    '<**>'<A, B>(fa: MaybeTBox<A>, f: MaybeTBox<FunctionArrow<A, B>>): MaybeTBox<B>
+
+    fmap<A, B>(f: (a: A) => B, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    '<$'<A, B>(a: A, fb: MaybeTBox<B>): MaybeTBox<A>
+
+    '$>'<A, B>(fa: MaybeTBox<A>, b: B): MaybeTBox<B>
+
+    '<&>'<A, B>(fa: MaybeTBox<A>, f: (a: A) => B): MaybeTBox<B>
+
+    void<A>(fa: MaybeTBox<A>): MaybeTBox<[]>
+}
+
+const baseImpl = (m: Monad): BaseImplementation => ({
+    pure: <A>(a: NonNullable<A>): MaybeTBox<A> => maybeT(() => m.pure(just(a) as MaybeBox<A>)),
+
+    '<*>': <A, B>(f: MaybeTBox<FunctionArrow<A, B>>, fa: MaybeTBox<A>): MaybeTBox<B> =>
+        maybeT(() =>
+            m['<*>'](
+                m['<$>'](
+                    (mf: MaybeBox<FunctionArrow<A, B>>) => (ma: MaybeBox<A>) =>
+                        maybeApplicative['<*>'](mf, ma) as MaybeBox<B>,
+                    f.runMaybeT(),
+                ),
+                fa.runMaybeT(),
+            ),
+        ),
+
+    liftA2: <A, B, C>(f: FunctionArrow2<A, B, NonNullable<C>>, fa: MaybeTBox<A>, fb: MaybeTBox<B>): MaybeTBox<C> =>
+        maybeT(() =>
+            m.liftA2(
+                (ma: MaybeBox<A>) => (mb: MaybeBox<B>) => maybeApplicative.liftA2(f, ma, mb),
+                fa.runMaybeT(),
+                fb.runMaybeT(),
+            ),
+        ),
+})
+
+export const applicative = (m: Monad): MaybeTApplicative => {
+    const functor = createFunctor(m)
+    return createApplicative(baseImpl(m), functor) as MaybeTApplicative
+}

--- a/src/control/monad/trans/maybe/functor.ts
+++ b/src/control/monad/trans/maybe/functor.ts
@@ -1,0 +1,33 @@
+import { Functor, functor as createFunctor, FunctorBase } from 'ghc/base/functor'
+import type { Monad } from 'ghc/base/monad/monad'
+import type { MinBox1 } from 'data/kind'
+import { MaybeBox } from 'ghc/base/maybe/maybe'
+import { functor as maybeFunctor } from 'ghc/base/maybe/functor'
+import { MaybeTBox, maybeT } from './maybe-t'
+
+export interface MaybeTFunctor extends Functor {
+    fmap<A, B>(f: (a: A) => B, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    '<$'<A, B>(a: A, fb: MaybeTBox<B>): MaybeTBox<A>
+
+    '$>'<A, B>(fa: MaybeTBox<A>, b: B): MaybeTBox<B>
+
+    '<&>'<A, B>(fa: MaybeTBox<A>, f: (a: A) => B): MaybeTBox<B>
+
+    void<A>(fa: MaybeTBox<A>): MaybeTBox<[]>
+}
+
+const base = (m: Monad): FunctorBase => ({
+    fmap: <A, B>(f: (a: A) => B, fa: MaybeTBox<A>): MaybeTBox<B> =>
+        maybeT(
+            () =>
+                m['<$>'](
+                    (mb: MaybeBox<A>) => maybeFunctor.fmap(f as (a: A) => B, mb) as unknown as MaybeBox<B>,
+                    fa.runMaybeT(),
+                ) as unknown as MinBox1<MaybeBox<B>>,
+        ),
+})
+
+export const functor = (m: Monad): MaybeTFunctor => createFunctor(base(m)) as MaybeTFunctor

--- a/src/control/monad/trans/maybe/maybe-t.ts
+++ b/src/control/monad/trans/maybe/maybe-t.ts
@@ -1,0 +1,23 @@
+import { Box1, MinBox0, MinBox1, Type } from 'data/kind'
+import type { Monad } from 'ghc/base/monad/monad'
+import { MaybeBox, just } from 'ghc/base/maybe/maybe'
+
+export interface MaybeT<A> {
+    readonly runMaybeT: () => MinBox1<MaybeBox<A>>
+}
+
+export type MaybeTBox<A> = MaybeT<A> & Box1<A>
+
+export type MaybeTMinBox<A> = MaybeT<MinBox0<A>> & Box1<MinBox0<A>>
+
+export const maybeT = <A>(fn: () => MinBox1<MaybeBox<A>>): MaybeTBox<A> => ({
+    runMaybeT: fn,
+    // Unary placeholder for kind annotation
+    kind: (_: '*') => '*' as Type,
+})
+
+export const runMaybeT = <A>(ma: MaybeT<A>): MinBox1<MaybeBox<A>> => ma.runMaybeT()
+
+// lift :: Monad m => m a -> MaybeT m a
+export const lift = <A>(m: Monad, ma: MinBox1<A>): MaybeTBox<A> =>
+    maybeT(() => m['<$>']((a: A) => just(a as NonNullable<A>), ma))

--- a/src/control/monad/trans/maybe/monad.ts
+++ b/src/control/monad/trans/maybe/monad.ts
@@ -1,0 +1,57 @@
+import { Monad, monad as createMonad } from 'ghc/base/monad/monad'
+import { applicative as createApplicative } from './applicative'
+import { MaybeTBox, maybeT } from './maybe-t'
+import { MaybeBox, $case, nothing } from 'ghc/base/maybe/maybe'
+import type { FunctionArrow, FunctionArrow2 } from 'ghc/prim/function-arrow'
+
+export interface MaybeTMonad extends Monad {
+    '>>='<A, B>(ma: MaybeTBox<A>, f: FunctionArrow<A, MaybeTBox<B>>): MaybeTBox<B>
+
+    '>>'<A, B>(ma: MaybeTBox<A>, mb: MaybeTBox<B>): MaybeTBox<B>
+
+    return<A>(a: NonNullable<A>): MaybeTBox<A>
+
+    pure<A>(a: NonNullable<A>): MaybeTBox<A>
+
+    '<*>'<A, B>(f: MaybeTBox<FunctionArrow<A, B>>, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    liftA2<A, B, C>(f: FunctionArrow2<A, B, C>, fa: MaybeTBox<A>, fb: MaybeTBox<B>): MaybeTBox<C>
+
+    '*>'<A, B>(fa: MaybeTBox<A>, fb: MaybeTBox<B>): MaybeTBox<B>
+
+    '<*'<A, B>(fa: MaybeTBox<A>, fb: MaybeTBox<B>): MaybeTBox<A>
+
+    '<**>'<A, B>(fa: MaybeTBox<A>, f: MaybeTBox<FunctionArrow<A, B>>): MaybeTBox<B>
+
+    fmap<A, B>(f: (a: A) => B, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    '<$>'<A, B>(f: (a: A) => B, fa: MaybeTBox<A>): MaybeTBox<B>
+
+    '<$'<A, B>(a: A, fb: MaybeTBox<B>): MaybeTBox<A>
+
+    '$>'<A, B>(fa: MaybeTBox<A>, b: B): MaybeTBox<B>
+
+    '<&>'<A, B>(fa: MaybeTBox<A>, f: (a: A) => B): MaybeTBox<B>
+
+    void<A>(fa: MaybeTBox<A>): MaybeTBox<[]>
+}
+
+const baseImplementation = (m: Monad) => ({
+    '>>=': <A, B>(ma: MaybeTBox<A>, f: FunctionArrow<A, MaybeTBox<B>>): MaybeTBox<B> =>
+        maybeT(() =>
+            m['>>='](
+                ma.runMaybeT(),
+                (mb: MaybeBox<A>): ReturnType<typeof m.return> =>
+                    $case<A, ReturnType<typeof m.return>>({
+                        just: (x: A) => f(x).runMaybeT(),
+                        nothing: () => m.pure(nothing<B>() as MaybeBox<B>),
+                    })(mb),
+            ),
+        ),
+})
+
+export const monad = (m: Monad): MaybeTMonad => {
+    const base = baseImplementation(m)
+    const app = createApplicative(m)
+    return createMonad(base, app) as MaybeTMonad
+}

--- a/src/control/monad/trans/monad-trans.ts
+++ b/src/control/monad/trans/monad-trans.ts
@@ -4,6 +4,10 @@ import type { Monoid } from 'ghc/base/monoid'
 import { ReaderTBox, readerT as makeReaderT } from './reader/reader-t'
 import { WriterTBox, writerT as makeWriterT } from './writer/writer-t'
 import { StateTBox, stateT as makeStateT } from './state/state-t'
+import { MaybeTBox, maybeT as makeMaybeT } from './maybe/maybe-t'
+import { EitherTBox, eitherT as makeEitherT } from './either/either-t'
+import { just } from 'ghc/base/maybe/maybe'
+import { right, EitherBox } from 'data/either/either'
 import { tuple2 } from 'ghc/base/tuple/tuple'
 
 export type MonadTransBase = {
@@ -36,6 +40,16 @@ export interface StateTTrans<S> extends MonadTrans {
     lift<A>(ma: MinBox1<A>): StateTBox<S, A>
 }
 
+// MaybeT-specific MonadTrans exposing a precise return type
+export interface MaybeTTrans extends MonadTrans {
+    lift<A>(ma: MinBox1<A>): MaybeTBox<A>
+}
+
+// EitherT/ExceptT-specific MonadTrans exposing a precise return type
+export interface EitherTTrans<E> extends MonadTrans {
+    lift<A>(ma: MinBox1<A>): EitherTBox<E, A>
+}
+
 export const readerT = <R>(m: Monad): ReaderTTrans<R> =>
     ({
         lift: <A>(ma: MinBox1<A>): ReaderTBox<R, A> => makeReaderT((_r: R) => ma),
@@ -54,3 +68,25 @@ export const stateT = <S>(m: Monad): StateTTrans<S> =>
         lift: <A>(ma: MinBox1<A>): StateTBox<S, A> => makeStateT((s: S) => m['<$>']((a: A) => tuple2(a, s), ma)),
         kind: kindOf(null as unknown as MonadTrans) as (_: (_: (_: '*') => '*') => (_: '*') => '*') => 'Constraint',
     }) as StateTTrans<S>
+
+export const maybeT = (m: Monad): MaybeTTrans =>
+    ({
+        lift: <A>(ma: MinBox1<A>): MaybeTBox<A> => makeMaybeT(() => m['<$>']((a: A) => just(a as NonNullable<A>), ma)),
+        kind: kindOf(null as unknown as MonadTrans) as (_: (_: (_: '*') => '*') => (_: '*') => '*') => 'Constraint',
+    }) as MaybeTTrans
+
+export const eitherT = <E>(m: Monad): EitherTTrans<E> =>
+    ({
+        lift: <A>(ma: MinBox1<A>): EitherTBox<E, A> =>
+            makeEitherT(
+                () =>
+                    m['<$>']((a: A) => right<E, A>(a as NonNullable<A>) as EitherBox<E, A>, ma) as MinBox1<
+                        EitherBox<E, A>
+                    >,
+            ),
+        kind: kindOf(null as unknown as MonadTrans) as (_: (_: (_: '*') => '*') => (_: '*') => '*') => 'Constraint',
+    }) as EitherTTrans<E>
+
+// ExceptT behaves the same as EitherT
+export type ExceptTTrans<E> = EitherTTrans<E>
+export const exceptT = <E>(m: Monad): EitherTTrans<E> => eitherT<E>(m)

--- a/test/control/alternative/either-alternative.generic.test.ts
+++ b/test/control/alternative/either-alternative.generic.test.ts
@@ -1,0 +1,55 @@
+import tap from 'tap'
+import { alternative as makeAlternative, BaseImplementation } from 'control/alternative/alternative'
+import { applicative as eitherApplicative } from 'data/either/applicative'
+import { left, right, $case, EitherBox } from 'data/either/either'
+import { nil, toArray, ListBox } from 'ghc/base/list/list'
+
+// Build Alternative over Either Applicative using a left-biased success choice:
+// - empty = Left("EMPTY")
+// - fa <|> fb = if fa is Right then fa else fb (recover from error)
+const base: BaseImplementation = {
+    empty: <A>() => left<string, A>('EMPTY') as unknown as EitherBox<string, A>,
+    '<|>': <A>(fa: EitherBox<string, A>, fb: EitherBox<string, A>): EitherBox<string, A> =>
+        $case<string, A, EitherBox<string, A>>({ left: () => fb, right: () => fa })(fa),
+}
+
+const alt = makeAlternative(base, eitherApplicative<string>())
+
+tap.test('Alternative over Either (left-biased success)', (t) => {
+    // empty
+    const emptyRes = alt.empty<number>() as EitherBox<string, number>
+    const emptyTag = $case<string, number, string>({ left: (e) => e })(emptyRes)
+    t.equal(emptyTag, 'EMPTY')
+
+    // <|> prefers first Right
+    const preferLeftRight = alt['<|>'](right<string, number>(7), right<string, number>(9)) as EitherBox<string, number>
+    const preferLeftRightVal = $case<string, number, number>({ right: (x) => x })(preferLeftRight)
+    t.equal(preferLeftRightVal, 7)
+
+    // <|> recovers from first Left
+    const recover = alt['<|>'](left<string, number>('e1'), right<string, number>(42)) as EitherBox<string, number>
+    const recoverVal = $case<string, number, number>({ right: (x) => x })(recover)
+    t.equal(recoverVal, 42)
+
+    // <|> both Left picks second (by our definition)
+    const bothLeft = alt['<|>'](left<string, number>('e1'), left<string, number>('e2')) as EitherBox<string, number>
+    const bothLeftTag = $case<string, number, string>({ left: (e) => e })(bothLeft)
+    t.equal(bothLeftTag, 'e2')
+
+    // some/many with Right value produce Right ListBox
+    const someOne = alt.some(right<string, number>(5)) as EitherBox<string, ListBox<number>>
+    const someOneArr = $case<string, ListBox<number>, number[]>({ right: (lst) => toArray(lst) })(someOne)
+    t.same(someOneArr, [5])
+
+    const manyOne = alt.many(right<string, number>(3)) as EitherBox<string, ListBox<number>>
+    const manyOneArr = $case<string, ListBox<number>, number[]>({ right: (lst) => toArray(lst) })(manyOne)
+    t.same(manyOneArr, [3])
+
+    // Force guarded empty branch using sentinel nil cast as Either
+    const sentinel = nil<number>() as unknown as EitherBox<string, number>
+    const someEmpty = alt.some(sentinel) as EitherBox<string, ListBox<number>>
+    const someEmptyTag = $case<string, ListBox<number>, string>({ left: (e) => e })(someEmpty)
+    t.equal(someEmptyTag, 'EMPTY')
+
+    t.end()
+})

--- a/test/control/alternative/either-validation.generic.test.ts
+++ b/test/control/alternative/either-validation.generic.test.ts
@@ -1,0 +1,73 @@
+import tap from 'tap'
+import { alternative as makeAlternative, BaseImplementation } from 'control/alternative/alternative'
+import { applicative as eitherApplicative } from 'data/either/applicative'
+import { left, right, $case, EitherBox } from 'data/either/either'
+import { nil, concat, toArray, ListBox } from 'ghc/base/list/list'
+
+// Validation-style Alternative over Either, accumulating errors on the Left using List concatenation.
+// - empty = Left([])
+// - fa <|> fb =
+//     Right x           -> Right x
+//     Left e1 <|> Right y -> Right y
+//     Left e1 <|> Left e2 -> Left (e1 <> e2)
+const base: BaseImplementation = {
+    empty: <A>() => left<ListBox<string>, A>(nil<string>()) as unknown as EitherBox<ListBox<string>, A>,
+    '<|>': <A>(fa: EitherBox<ListBox<string>, A>, fb: EitherBox<ListBox<string>, A>): EitherBox<ListBox<string>, A> =>
+        $case<ListBox<string>, A, EitherBox<ListBox<string>, A>>({
+            right: () => fa,
+            left: (e1) =>
+                $case<ListBox<string>, A, EitherBox<ListBox<string>, A>>({
+                    right: () => fb,
+                    left: (e2) => left<ListBox<string>, A>(concat(e1, e2)),
+                })(fb),
+        })(fa),
+}
+
+const altValidation = makeAlternative(base, eitherApplicative<ListBox<string>>())
+
+tap.test('Alternative over Either (Validation-style, accumulates Left errors)', (t) => {
+    // empty is Left []
+    const emptyRes = altValidation.empty<number>() as EitherBox<ListBox<string>, number>
+    const emptyArr = $case<ListBox<string>, number, string[]>({ left: (es) => toArray(es) })(emptyRes)
+    t.same(emptyArr, [])
+
+    // Prefer first Right
+    const firstRight = altValidation['<|>'](
+        right<ListBox<string>, number>(1),
+        right<ListBox<string>, number>(2),
+    ) as EitherBox<ListBox<string>, number>
+    const firstRightVal = $case<ListBox<string>, number, number>({ right: (x) => x })(firstRight)
+    t.equal(firstRightVal, 1)
+
+    // Recover from Left on the left
+    const recover = altValidation['<|>'](
+        left<ListBox<string>, number>(nil<string>()),
+        right<ListBox<string>, number>(7),
+    ) as EitherBox<ListBox<string>, number>
+    const recoverVal = $case<ListBox<string>, number, number>({ right: (x) => x })(recover)
+    t.equal(recoverVal, 7)
+
+    // Accumulate errors when both sides are Left
+    const e1 = left<ListBox<string>, number>(concat(nil<string>(), nil<string>()))
+    const e2 = left<ListBox<string>, number>(concat(nil<string>(), nil<string>()))
+    const bothLeft = altValidation['<|>'](e1, e2) as EitherBox<ListBox<string>, number>
+    const bothLeftArr = $case<ListBox<string>, number, string[]>({ left: (es) => toArray(es) })(bothLeft)
+    t.same(bothLeftArr, [])
+
+    // some/many on Right produce Right list
+    const someOne = altValidation.some(right<ListBox<string>, number>(3)) as EitherBox<ListBox<string>, ListBox<number>>
+    const someOneArr = $case<ListBox<string>, ListBox<number>, number[]>({ right: (xs) => toArray(xs) })(someOne)
+    t.same(someOneArr, [3])
+
+    const manyOne = altValidation.many(right<ListBox<string>, number>(5)) as EitherBox<ListBox<string>, ListBox<number>>
+    const manyOneArr = $case<ListBox<string>, ListBox<number>, number[]>({ right: (xs) => toArray(xs) })(manyOne)
+    t.same(manyOneArr, [5])
+
+    // Sentinel empty branch (use nil cast) yields empty (Left [])
+    const sentinel = nil<number>() as unknown as EitherBox<ListBox<string>, number>
+    const someEmpty = altValidation.some(sentinel) as EitherBox<ListBox<string>, ListBox<number>>
+    const someEmptyArr = $case<ListBox<string>, ListBox<number>, string[]>({ left: (es) => toArray(es) })(someEmpty)
+    t.same(someEmptyArr, [])
+
+    t.end()
+})

--- a/test/control/alternative/generic-alternative.test.ts
+++ b/test/control/alternative/generic-alternative.test.ts
@@ -1,0 +1,136 @@
+import tap from 'tap'
+import { alternative as makeAlternative, BaseImplementation, __testing } from 'control/alternative/alternative'
+import { applicative as maybeApplicative } from 'ghc/base/maybe/applicative'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+import { nil, toArray, ListBox, cons, concat } from 'ghc/base/list/list'
+import { MinBox1 } from 'data/kind'
+import { applicative as listApplicative } from 'ghc/base/list/applicative'
+
+// Build Alternative over Maybe Applicative using the generic combinators
+const base: BaseImplementation = {
+    empty: nothing,
+    '<|>': <A>(fa: MaybeBox<A>, fb: MaybeBox<A>): MaybeBox<A> =>
+        $case<A, MaybeBox<A>>({
+            // prefer the left if it is Just
+            just: () => fa,
+            // otherwise return the right
+            nothing: () => fb,
+        })(fa),
+}
+
+const alt = makeAlternative(base, maybeApplicative)
+
+const fromMaybe = <A>(ma: MaybeBox<A>): A => $case<A, A>({ just: (x) => x })(ma)
+
+tap.test('Alternative (generic) some/many and empty branch', (t) => {
+    // some should take exactly one when left-biased and succeed
+    const someOne = alt.some(just(7)) as MaybeBox<ListBox<number>>
+    t.same(toArray(fromMaybe(someOne)), [7])
+
+    // many should take one (left-biased) when value exists
+    const manyOne = alt.many(just(3)) as MaybeBox<ListBox<number>>
+    t.same(toArray(fromMaybe(manyOne)), [3])
+
+    // Pass a sentinel that looks like an empty List to hit the $null branch
+    const sentinelEmptyList = nil<number>() as unknown as MaybeBox<number>
+
+    const result = alt.some(sentinelEmptyList) as MaybeBox<ListBox<number>>
+    // Expect empty (Nothing) from base.empty
+    const tag = $case<ListBox<number>, string>({ nothing: () => 'none', just: () => 'some' })(result)
+    t.equal(tag, 'none')
+
+    t.end()
+})
+
+tap.test('Alternative (generic) lazy branch defers evaluation', (t) => {
+    let invoked = 0
+    const lazyThunk = () => {
+        invoked += 1
+        const fn = (() => 42) as MaybeBox<number>
+        ;(fn as unknown as { kind: unknown }).kind = 'initial'
+        ;(fn as unknown as { prop: number }).prop = 10
+        return fn
+    }
+
+    const lazy = __testing.defer(lazyThunk)
+    t.equal(invoked, 0, 'defer should not evaluate immediately')
+
+    type LazyFn = (() => unknown) & { kind: unknown }
+    const lazyFunc = lazy as unknown as LazyFn
+    lazyFunc.kind = 'custom'
+    t.equal(invoked, 1, 'setter should trigger evaluation once')
+    t.equal(lazyFunc.kind, 'custom', 'kind setter forwards to underlying object')
+
+    lazyFunc()
+    t.equal(invoked, 1, 'subsequent calls reuse cached value')
+
+    t.end()
+})
+
+tap.test('Alternative defer proxies object properties', (t) => {
+    let invoked = 0
+    const lazy = __testing.defer(() => {
+        invoked += 1
+        return { value: 5, kind: 'seed' } as unknown as MinBox1<number>
+    })
+
+    t.equal(invoked, 0, 'object thunk is not evaluated eagerly')
+
+    type LazyObject = { value: number; kind: string }
+    const proxy = lazy as unknown as LazyObject
+    proxy.kind = 'custom'
+    t.equal(invoked, 1, 'setting property forces evaluation once')
+    t.equal(proxy.value, 5, 'getter reflects cached object property')
+
+    proxy.value = 9
+    t.equal(proxy.value, 9, 'setter updates cached object property')
+
+    t.end()
+})
+
+tap.test('Alternative (generic) list detection guards invalid inputs', (t) => {
+    t.notOk(__testing.isListLike(42 as unknown as MaybeBox<number>), 'non-functions are never list-like')
+
+    const bomb = (() => {
+        throw new Error('boom')
+    }) as unknown as MaybeBox<number>
+    t.notOk(__testing.isListLike(bomb), 'failing thunks are treated as non list-like')
+
+    t.end()
+})
+
+// Helper to build ListBox from array for readability
+const listOf = (...xs: number[]): ListBox<number> => xs.reduceRight((acc, x) => cons(x)(acc), nil<number>())
+
+tap.test('Alternative (generic over List) produces combinations and respects empty', (t) => {
+    // Build Alternative over List Applicative
+    const listBase: BaseImplementation = { empty: nil, '<|>': concat as unknown as BaseImplementation['<|>'] }
+
+    const altList = makeAlternative(listBase, listApplicative)
+
+    // some with a non-empty list produces lists of length >= 1; take first 4 combinations
+    const someList = altList.some(listOf(1, 2)) as unknown as ListBox<ListBox<number>>
+    const someFirst4 = toArray(someList)
+        .slice(0, 4)
+        .map((lst) => toArray(lst as unknown as ListBox<number>))
+    // expect [ [1], [2], [1,1], [1,2] ] due to left-bias expanding by length
+    t.same(someFirst4, [[1], [2], [1, 1], [1, 2]])
+
+    // many should include [] appended via pure(nil()) at the end of '<|>' chain
+    const manyList = altList.many(listOf(1, 2)) as unknown as ListBox<ListBox<number>>
+    const manyFirst4 = toArray(manyList)
+        .slice(0, 4)
+        .map((lst) => toArray(lst as unknown as ListBox<number>))
+    t.same(manyFirst4, [[1], [2], [1, 1], [1, 2]])
+
+    // some on empty list hits the guarded branch and returns empty
+    const someEmpty = altList.some(nil<number>()) as ListBox<ListBox<number>>
+    t.same(toArray(someEmpty), [])
+
+    // many on empty list should return a list containing only the empty list
+    const manyEmpty = altList.many(nil<number>()) as ListBox<ListBox<number>>
+    const manyEmptyFlattened = toArray(manyEmpty).map((lst) => toArray(lst as ListBox<number>))
+    t.same(manyEmptyFlattened, [[]])
+
+    t.end()
+})

--- a/test/control/monad-plus/builder.test.ts
+++ b/test/control/monad-plus/builder.test.ts
@@ -1,0 +1,31 @@
+import tap from 'tap'
+import { monad as listMonad } from 'ghc/base/list/monad'
+import { alternative as listAlternative } from 'ghc/base/list/alternative'
+import { monadPlus as createMonadPlus, BaseImplementation, guard } from 'control/monad-plus/monad-plus'
+import { cons, nil, toArray, concat, ListBox } from 'ghc/base/list/list'
+
+const listOf = (...xs: number[]): ListBox<number> => xs.reduceRight((acc, x) => cons(x)(acc), nil<number>())
+
+tap.test('MonadPlus builder over List', async (t) => {
+    const base: BaseImplementation = {
+        mzero: nil,
+        mplus: concat as unknown as BaseImplementation['mplus'],
+    }
+
+    const mp = createMonadPlus(base, listMonad, listAlternative<number>())
+
+    // msum concatenates a list of lists
+    const l1 = listOf(1)
+    const l2 = listOf(2)
+    const l3 = listOf(3)
+    const listOfLists = cons(l1)(cons(l2)(cons(l3)(nil<ListBox<number>>())))
+    const msumRes = mp.msum(listOfLists) as ListBox<number>
+    t.same(toArray(msumRes), [1, 2, 3])
+
+    // guard integrates with MonadPlus
+    const g = guard(mp)
+    const ok = g(true) as ListBox<[]>
+    const no = g(false) as ListBox<[]>
+    t.same(toArray(ok), [[]])
+    t.same(toArray(no), [])
+})

--- a/test/control/monad/trans/either-t.test.ts
+++ b/test/control/monad/trans/either-t.test.ts
@@ -1,0 +1,166 @@
+import tap from 'tap'
+import { monad as promiseMonad } from 'extra/promise/monad'
+import { right, left, $case, EitherBox } from 'data/either/either'
+import { functor as eitherTFunctor } from 'control/monad/trans/either/functor'
+import { applicative as eitherTApplicative } from 'control/monad/trans/either/applicative'
+import { monad as eitherTMonad } from 'control/monad/trans/either/monad'
+import {
+    eitherT as mkEitherT,
+    runEitherT as runEitherTHelper,
+    lift as liftLocal,
+} from 'control/monad/trans/either/either-t'
+import { eitherT as eitherTTrans } from 'control/monad/trans/monad-trans'
+
+const promiseMonadInstance = promiseMonad
+
+const toPromise = <T>(x: unknown): Promise<T> => x as Promise<T>
+
+const fromEither = async <E, A>(pea: unknown): Promise<A> => {
+    const ea = (await toPromise<EitherBox<E, A>>(pea)) as EitherBox<E, A>
+    return $case<E, A, A>({
+        right: (x) => x,
+        left: (e) => {
+            throw new Error('Left: ' + String(e))
+        },
+    })(ea)
+}
+
+tap.test('EitherT Functor and derived ops', async (t) => {
+    const eitherTFunctorInstance = eitherTFunctor<number>(promiseMonadInstance)
+    const eitherSource = mkEitherT<number, number>(
+        () => Promise.resolve(right(2)) as unknown as import('data/kind').MinBox1<EitherBox<number, number>>,
+    )
+
+    // fmap
+    const mapped = eitherTFunctorInstance.fmap((x: number) => x + 3, eitherSource)
+    t.equal(await fromEither(runEitherTHelper(mapped)), 5)
+
+    // <$>
+    const appliedResult = eitherTFunctorInstance['<$>']((x: number) => x * 4, eitherSource)
+    t.equal(await fromEither(runEitherTHelper(appliedResult)), 8)
+
+    // <$ (replace value)
+    const replacedResult = eitherTFunctorInstance['<$']('a', eitherSource)
+    t.equal(await fromEither(runEitherTHelper(replacedResult)), 'a')
+
+    // $> (keep right)
+    const keepRightResult = eitherTFunctorInstance['$>'](eitherSource, true)
+    t.equal(await fromEither(runEitherTHelper(keepRightResult)), true)
+
+    // <&>
+    const mappedRightResult = eitherTFunctorInstance['<&>'](eitherSource, (x: number) => x - 1)
+    t.equal(await fromEither(runEitherTHelper(mappedRightResult)), 1)
+})
+tap.test('EitherT Applicative and sequencing', async (t) => {
+    const eitherTApplicativeInstance = eitherTApplicative<string>(promiseMonadInstance)
+
+    // pure
+    t.equal(await fromEither(runEitherTHelper(eitherTApplicativeInstance.pure(9))), 9)
+
+    // <*> with both Right
+    const functionInEitherT = mkEitherT<string, (_: number) => number>(
+        () =>
+            Promise.resolve(right((x: number) => x + 1)) as unknown as import('data/kind').MinBox1<
+                EitherBox<string, (_: number) => number>
+            >,
+    )
+    const valueInEitherT = mkEitherT<string, number>(
+        () => Promise.resolve(right(10)) as unknown as import('data/kind').MinBox1<EitherBox<string, number>>,
+    )
+    t.equal(
+        await fromEither(runEitherTHelper(eitherTApplicativeInstance['<*>'](functionInEitherT, valueInEitherT))),
+        11,
+    )
+
+    // <*> with Left function
+    const functionLeft = mkEitherT<string, (_: number) => number>(
+        () =>
+            Promise.resolve(left('errF')) as unknown as import('data/kind').MinBox1<
+                EitherBox<string, (_: number) => number>
+            >,
+    )
+    const resultLeft = await toPromise(
+        runEitherTHelper(eitherTApplicativeInstance['<*>'](functionLeft, valueInEitherT)),
+    )
+    t.equal($case<string, number, string>({ left: (e) => e })(resultLeft as EitherBox<string, number>), 'errF')
+
+    // liftA2 and derived ops <* , *>
+    const firstEitherValue = mkEitherT<string, number>(
+        () => Promise.resolve(right(2)) as unknown as import('data/kind').MinBox1<EitherBox<string, number>>,
+    )
+    const secondEitherValue = mkEitherT<string, number>(
+        () => Promise.resolve(right(3)) as unknown as import('data/kind').MinBox1<EitherBox<string, number>>,
+    )
+    t.equal(
+        await fromEither(
+            runEitherTHelper(
+                eitherTApplicativeInstance.liftA2(
+                    (x: number) => (y: number) => x + y,
+                    firstEitherValue,
+                    secondEitherValue,
+                ),
+            ),
+        ),
+        5,
+    )
+
+    t.equal(
+        await fromEither(runEitherTHelper(eitherTApplicativeInstance['<*'](firstEitherValue, secondEitherValue))),
+        2,
+    )
+    t.equal(
+        await fromEither(runEitherTHelper(eitherTApplicativeInstance['*>'](firstEitherValue, secondEitherValue))),
+        3,
+    )
+})
+
+tap.test('EitherT Monad bind/return/>> and lifts', async (t) => {
+    const eitherTMonadInstance = eitherTMonad<string>(promiseMonadInstance)
+    const returnValue = (x: number) => eitherTMonadInstance.return(x)
+
+    // >>= success
+    const doubleValue = (x: number) =>
+        mkEitherT<string, number>(
+            () => Promise.resolve(right(x * 2)) as unknown as import('data/kind').MinBox1<EitherBox<string, number>>,
+        )
+    t.equal(await fromEither(runEitherTHelper(eitherTMonadInstance['>>='](returnValue(5), doubleValue))), 10)
+
+    // >>= propagate Left
+    const leftValue = mkEitherT<string, number>(
+        () => Promise.resolve(left('oops')) as unknown as import('data/kind').MinBox1<EitherBox<string, number>>,
+    )
+    const resultFromLeft = await toPromise(runEitherTHelper(eitherTMonadInstance['>>='](leftValue, doubleValue)))
+    t.equal($case<string, number, string>({ left: (e) => e })(resultFromLeft as EitherBox<string, number>), 'oops')
+
+    // >> sequencing
+    const firstAction = mkEitherT<string, number>(
+        () => Promise.resolve(right(1)) as unknown as import('data/kind').MinBox1<EitherBox<string, number>>,
+    )
+    const secondAction = mkEitherT<string, string>(
+        () => Promise.resolve(right('ok')) as unknown as import('data/kind').MinBox1<EitherBox<string, string>>,
+    )
+    const sequencedResult = eitherTMonadInstance['>>'](firstAction, secondAction)
+    t.equal(await fromEither(runEitherTHelper(sequencedResult)), 'ok')
+
+    // local lift
+    const liftedLocal = liftLocal<string, number>(
+        promiseMonadInstance,
+        Promise.resolve(42) as unknown as import('data/kind').MinBox1<number>,
+    )
+    t.equal(await fromEither(runEitherTHelper(liftedLocal)), 42)
+
+    // class lift (MonadTrans.eitherT)
+    const eitherTTransformer = eitherTTrans<string>(promiseMonadInstance)
+    const liftedViaTransformer = eitherTTransformer.lift(
+        Promise.resolve(7) as unknown as import('data/kind').MinBox1<number>,
+    )
+    t.equal(await fromEither(runEitherTHelper(liftedViaTransformer)), 7)
+})
+
+tap.test('EitherT kind function', async (t) => {
+    const kindCheckObj = mkEitherT<string, string>(
+        () => Promise.resolve(right('x')) as unknown as import('data/kind').MinBox1<EitherBox<string, string>>,
+    )
+    const kindFn = (kindCheckObj as unknown as { kind: (_: unknown) => (_: unknown) => string }).kind
+    t.equal(kindFn('*')('*'), '*')
+})

--- a/test/control/monad/trans/except-t.test.ts
+++ b/test/control/monad/trans/except-t.test.ts
@@ -1,0 +1,60 @@
+import tap from 'tap'
+import { monad as promiseMonad } from 'extra/promise/monad'
+import { right, $case, EitherBox } from 'data/either/either'
+import { functor as exceptTFunctor } from 'control/monad/trans/except/functor'
+import { applicative as exceptTApplicative } from 'control/monad/trans/except/applicative'
+import { monad as exceptTMonad } from 'control/monad/trans/except/monad'
+import {
+    exceptT as mkExceptT,
+    runExceptT as runExceptTHelper,
+    lift as liftLocal,
+} from 'control/monad/trans/except/except-t'
+import { exceptT as exceptTTrans } from 'control/monad/trans/monad-trans'
+
+const promiseMonadInstance = promiseMonad
+
+const toPromise = <T>(x: unknown): Promise<T> => x as Promise<T>
+
+const fromExcept = async <E, A>(pea: unknown): Promise<A> => {
+    const ea = (await toPromise<EitherBox<E, A>>(pea)) as EitherBox<E, A>
+    return $case<E, A, A>({ right: (x) => x })(ea)
+}
+
+tap.test('ExceptT behaves as EitherT: Functor/Applicative/Monad and lifts', async (t) => {
+    const exceptTFunctorInstance = exceptTFunctor<string>(promiseMonadInstance)
+    const exceptTApplicativeInstance = exceptTApplicative<string>(promiseMonadInstance)
+    const exceptTMonadInstance = exceptTMonad<string>(promiseMonadInstance)
+
+    const sourceExcept = mkExceptT<string, number>(
+        () => Promise.resolve(right(3)) as unknown as import('data/kind').MinBox1<EitherBox<string, number>>,
+    )
+    t.equal(await fromExcept(runExceptTHelper(exceptTFunctorInstance['<$>']((x: number) => x + 1, sourceExcept))), 4)
+
+    const functionInExceptT = mkExceptT<string, (_: number) => number>(
+        () =>
+            Promise.resolve(right((x: number) => x * 2)) as unknown as import('data/kind').MinBox1<
+                EitherBox<string, (_: number) => number>
+            >,
+    )
+    t.equal(await fromExcept(runExceptTHelper(exceptTApplicativeInstance['<*>'](functionInExceptT, sourceExcept))), 6)
+
+    const returnValue = (x: number) => exceptTMonadInstance.return(x)
+    t.equal(
+        await fromExcept(runExceptTHelper(exceptTMonadInstance['>>='](returnValue(5), (n: number) => sourceExcept))),
+        3,
+    )
+
+    // local lift
+    const liftedLocal = liftLocal<string, number>(
+        promiseMonadInstance,
+        Promise.resolve(9) as unknown as import('data/kind').MinBox1<number>,
+    )
+    t.equal(await fromExcept(runExceptTHelper(liftedLocal)), 9)
+
+    // class lift via MonadTrans
+    const exceptTTransformer = exceptTTrans<string>(promiseMonadInstance)
+    const liftedViaTransformer = exceptTTransformer.lift(
+        Promise.resolve(7) as unknown as import('data/kind').MinBox1<number>,
+    )
+    t.equal(await fromExcept(runExceptTHelper(liftedViaTransformer)), 7)
+})

--- a/test/control/monad/trans/maybe-t.test.ts
+++ b/test/control/monad/trans/maybe-t.test.ts
@@ -1,0 +1,275 @@
+import tap from 'tap'
+import { monad as promiseMonad } from 'extra/promise/monad'
+import { just, nothing, $case, MaybeBox } from 'ghc/base/maybe/maybe'
+import { functor as maybeTFunctor } from 'control/monad/trans/maybe/functor'
+import { applicative as maybeTApplicative } from 'control/monad/trans/maybe/applicative'
+import { monad as maybeTMonad } from 'control/monad/trans/maybe/monad'
+import { maybeT as mkMaybeT, runMaybeT as runMaybeTHelper, lift as liftLocal } from 'control/monad/trans/maybe/maybe-t'
+import { maybeT as maybeTTrans } from 'control/monad/trans/monad-trans'
+import { monad as stateTMonad } from 'control/monad/trans/state/monad'
+import { stateT as mkStateT, runStateT, tuple as stTuple, StateTBox } from 'control/monad/trans/state/state-t'
+import { monad as readerTMonad } from 'control/monad/trans/reader/monad'
+import { readerT as mkReaderT, runReaderT, ReaderTBox } from 'control/monad/trans/reader/reader-t'
+import { monad as writerTMonad } from 'control/monad/trans/writer/monad'
+import { writerT as mkWriterT, runWriterT, tuple as wrTuple, WriterTBox } from 'control/monad/trans/writer/writer-t'
+import { monoid as listMonoid } from 'ghc/base/list/monoid'
+import { cons, nil, toArray, ListBox } from 'ghc/base/list/list'
+import type { Tuple2Box } from 'ghc/base/tuple/tuple'
+
+const promiseMonadInstance = promiseMonad
+
+const toPromise = <T>(x: unknown): Promise<T> => x as Promise<T>
+
+const fromMaybe = async <A>(pma: unknown): Promise<A> => {
+    const ma = (await toPromise<MaybeBox<A>>(pma)) as MaybeBox<A>
+    return $case<A, A>({
+        just: (x) => x,
+        nothing: () => {
+            throw new Error('Nothing')
+        },
+    })(ma)
+}
+
+tap.test('MaybeT Functor and derived ops', async (t) => {
+    const maybeTFunctorInstance = maybeTFunctor(promiseMonadInstance)
+    const maybeSource = mkMaybeT<number>(
+        () => Promise.resolve(just(2)) as unknown as import('data/kind').MinBox1<MaybeBox<number>>,
+    )
+
+    // fmap
+    const mapped = maybeTFunctorInstance.fmap((x: number) => x + 3, maybeSource)
+    t.equal(await fromMaybe(runMaybeTHelper(mapped)), 5)
+
+    // <$>
+    const appliedResult = maybeTFunctorInstance['<$>']((x: number) => x * 4, maybeSource)
+    t.equal(await fromMaybe(runMaybeTHelper(appliedResult)), 8)
+
+    // <$ (replace value)
+    const replacedResult = maybeTFunctorInstance['<$']('a', maybeSource)
+    t.equal(await fromMaybe(runMaybeTHelper(replacedResult)), 'a')
+
+    // $> (keep right)
+    const keepRightResult = maybeTFunctorInstance['$>'](maybeSource, true)
+    t.equal(await fromMaybe(runMaybeTHelper(keepRightResult)), true)
+
+    // <&>
+    const mappedRightResult = maybeTFunctorInstance['<&>'](maybeSource, (x: number) => x - 1)
+    t.equal(await fromMaybe(runMaybeTHelper(mappedRightResult)), 1)
+
+    // void
+    const voidedResult = maybeTFunctorInstance.void(maybeSource)
+    t.same(await fromMaybe(runMaybeTHelper(voidedResult)), [])
+})
+tap.test('MaybeT Applicative and sequencing', async (t) => {
+    const maybeTApplicativeInstance = maybeTApplicative(promiseMonadInstance)
+
+    // pure
+    t.equal(await fromMaybe(runMaybeTHelper(maybeTApplicativeInstance.pure(9))), 9)
+
+    // <*> with both Just
+    const functionInMaybeT = mkMaybeT<(_: number) => number>(
+        () =>
+            Promise.resolve(just((x: number) => x + 1)) as unknown as import('data/kind').MinBox1<
+                MaybeBox<(_: number) => number>
+            >,
+    )
+    const valueInMaybeT = mkMaybeT<number>(
+        () => Promise.resolve(just(10)) as unknown as import('data/kind').MinBox1<MaybeBox<number>>,
+    )
+    t.equal(await fromMaybe(runMaybeTHelper(maybeTApplicativeInstance['<*>'](functionInMaybeT, valueInMaybeT))), 11)
+
+    // <*> with Nothing function
+    const functionNothing = mkMaybeT<(_: number) => number>(
+        () => Promise.resolve(nothing()) as unknown as import('data/kind').MinBox1<MaybeBox<(_: number) => number>>,
+    )
+    const resultNothing = await toPromise(
+        runMaybeTHelper(maybeTApplicativeInstance['<*>'](functionNothing, valueInMaybeT)),
+    )
+    t.equal($case({ nothing: () => 'none', just: () => 'some' })(resultNothing as unknown as MaybeBox<number>), 'none')
+
+    // liftA2 and derived ops <* , *>, <**>
+    const firstValueMaybeT = mkMaybeT<number>(
+        () => Promise.resolve(just(2)) as unknown as import('data/kind').MinBox1<MaybeBox<number>>,
+    )
+    const secondValueMaybeT = mkMaybeT<number>(
+        () => Promise.resolve(just(3)) as unknown as import('data/kind').MinBox1<MaybeBox<number>>,
+    )
+    t.equal(
+        await fromMaybe(
+            runMaybeTHelper(
+                maybeTApplicativeInstance.liftA2(
+                    (x: number) => (y: number) => x + y,
+                    firstValueMaybeT,
+                    secondValueMaybeT,
+                ),
+            ),
+        ),
+        5,
+    )
+
+    t.equal(await fromMaybe(runMaybeTHelper(maybeTApplicativeInstance['<*'](firstValueMaybeT, secondValueMaybeT))), 2)
+    t.equal(await fromMaybe(runMaybeTHelper(maybeTApplicativeInstance['*>'](firstValueMaybeT, secondValueMaybeT))), 3)
+    t.equal(await fromMaybe(runMaybeTHelper(maybeTApplicativeInstance['<**>'](firstValueMaybeT, functionInMaybeT))), 3)
+})
+
+tap.test('MaybeT Monad bind/return/>> and lifts', async (t) => {
+    const maybeTMonadInstance = maybeTMonad(promiseMonadInstance)
+    const returnValue = (x: number) => maybeTMonadInstance.return(x)
+
+    // >>= success
+    const doubleValue = (x: number) =>
+        mkMaybeT<number>(() => Promise.resolve(just(x * 2)) as unknown as import('data/kind').MinBox1<MaybeBox<number>>)
+    t.equal(await fromMaybe(runMaybeTHelper(maybeTMonadInstance['>>='](returnValue(5), doubleValue))), 10)
+
+    // >>= propagate Nothing
+    const nothingInMaybeT = mkMaybeT<number>(
+        () => Promise.resolve(nothing()) as unknown as import('data/kind').MinBox1<MaybeBox<number>>,
+    )
+    const resultFromNothing = await toPromise(runMaybeTHelper(maybeTMonadInstance['>>='](nothingInMaybeT, doubleValue)))
+    t.equal(
+        $case({ nothing: () => 'none', just: () => 'some' })(resultFromNothing as unknown as MaybeBox<number>),
+        'none',
+    )
+
+    // >> sequencing
+    const firstAction = mkMaybeT<number>(
+        () => Promise.resolve(just(1)) as unknown as import('data/kind').MinBox1<MaybeBox<number>>,
+    )
+    const secondAction = mkMaybeT<string>(
+        () => Promise.resolve(just('ok')) as unknown as import('data/kind').MinBox1<MaybeBox<string>>,
+    )
+    const sequencedResult = maybeTMonadInstance['>>'](firstAction, secondAction)
+    t.equal(await fromMaybe(runMaybeTHelper(sequencedResult)), 'ok')
+
+    // local lift
+    const liftedLocal = liftLocal<number>(
+        promiseMonadInstance,
+        Promise.resolve(42) as unknown as import('data/kind').MinBox1<number>,
+    )
+    t.equal(await fromMaybe(runMaybeTHelper(liftedLocal)), 42)
+
+    // class lift (MonadTrans.maybeT)
+    const maybeTTransformer = maybeTTrans(promiseMonadInstance)
+    const liftedViaTransformer = maybeTTransformer.lift(
+        Promise.resolve(7) as unknown as import('data/kind').MinBox1<number>,
+    )
+    t.equal(await fromMaybe(runMaybeTHelper(liftedViaTransformer)), 7)
+})
+
+tap.test('MaybeT kind function', async (t) => {
+    const kindCheckObj = mkMaybeT(
+        () => Promise.resolve(just('x')) as unknown as import('data/kind').MinBox1<MaybeBox<string>>,
+    )
+    const kindFn = (kindCheckObj as unknown as { kind: (_: unknown) => string }).kind
+    t.equal(kindFn('*'), '*')
+})
+
+tap.test('MaybeT over StateT with Promise base', async (t) => {
+    const basePromise = promiseMonadInstance
+    const stateTMonadInstance = stateTMonad<number>(basePromise)
+    const maybeTOverStateMonad = maybeTMonad(stateTMonadInstance)
+    const liftStateT = maybeTTrans(stateTMonadInstance).lift
+
+    const incrementState = mkStateT<number, number>(
+        (s: number) =>
+            Promise.resolve(stTuple(s + 1, s + 1)) as unknown as import('data/kind').MinBox1<Tuple2Box<number, number>>,
+    )
+
+    const program = maybeTOverStateMonad['>>='](liftStateT(incrementState), (a: number) =>
+        maybeTOverStateMonad['>>='](liftStateT(incrementState), (b: number) => maybeTOverStateMonad.return(a + b)),
+    )
+
+    const stateResult = (await toPromise(
+        runStateT(runMaybeTHelper(program) as unknown as StateTBox<number, MaybeBox<number>>, 10),
+    )) as Tuple2Box<MaybeBox<number>, number>
+    const maybeValue = stateResult[0] as MaybeBox<number>
+    t.equal($case({ just: (x: number) => x })(maybeValue), 23)
+    t.equal(stateResult[1], 12)
+})
+
+tap.test('MaybeT over StateT short-circuits', async (t) => {
+    const basePromise2 = promiseMonadInstance
+    const stateTMonadInstance2 = stateTMonad<number>(basePromise2)
+    const maybeTOverStateMonad2 = maybeTMonad(stateTMonadInstance2)
+    const liftStateT2 = maybeTTrans(stateTMonadInstance2).lift
+
+    const incrementState2 = mkStateT<number, number>(
+        (s: number) =>
+            Promise.resolve(stTuple(s + 1, s + 1)) as unknown as import('data/kind').MinBox1<Tuple2Box<number, number>>,
+    )
+
+    const failMaybeT = mkMaybeT<number>(
+        () =>
+            stateTMonadInstance2.return(nothing<number>()) as unknown as import('data/kind').MinBox1<MaybeBox<number>>,
+    )
+
+    const program2 = maybeTOverStateMonad2['>>='](liftStateT2(incrementState2), () =>
+        maybeTOverStateMonad2['>>='](failMaybeT, () => liftStateT2(incrementState2)),
+    )
+    const stateResult2 = (await toPromise(
+        runStateT(runMaybeTHelper(program2) as unknown as StateTBox<number, MaybeBox<number>>, 5),
+    )) as Tuple2Box<MaybeBox<number>, number>
+    const tagStr = $case({ nothing: () => 'none', just: () => 'some' })(stateResult2[0] as MaybeBox<number>)
+    t.equal(tagStr, 'none')
+    t.equal(stateResult2[1], 6)
+})
+
+tap.test('MaybeT over ReaderT with Promise base', async (t) => {
+    const basePromise3 = promiseMonadInstance
+    const readerTMonadInstance = readerTMonad<string>(basePromise3)
+    const maybeTOverReaderMonad = maybeTMonad(readerTMonadInstance)
+    const liftReaderT = maybeTTrans(readerTMonadInstance).lift
+
+    const askReader = mkReaderT<string, string>(
+        (r: string) => Promise.resolve(r) as unknown as import('data/kind').MinBox1<string>,
+    )
+
+    const programReader = maybeTOverReaderMonad['>>='](liftReaderT(askReader), (r: string) =>
+        r.length > 0
+            ? maybeTOverReaderMonad.return(r.toUpperCase())
+            : mkMaybeT(() => readerTMonadInstance.return(nothing())),
+    )
+
+    const readerOut1 = (await toPromise(
+        runReaderT(runMaybeTHelper(programReader) as unknown as ReaderTBox<string, MaybeBox<string>>, 'hi'),
+    )) as MaybeBox<string>
+    t.equal($case({ just: (x: string) => x })(readerOut1), 'HI')
+
+    const readerOut2 = (await toPromise(
+        runReaderT(runMaybeTHelper(programReader) as unknown as ReaderTBox<string, MaybeBox<string>>, ''),
+    )) as MaybeBox<string>
+    t.equal($case({ nothing: () => 'none', just: () => 'some' })(readerOut2), 'none')
+})
+
+tap.test('MaybeT over WriterT with Promise base and List log', async (t) => {
+    const basePromise4 = promiseMonadInstance
+    const listMonoidInstance = listMonoid<number>()
+    const writerTMonadInstance = writerTMonad(basePromise4, listMonoidInstance)
+    const maybeTOverWriterMonad = maybeTMonad(writerTMonadInstance)
+    const liftWriterT = maybeTTrans(writerTMonadInstance).lift
+
+    const tellList = (n: number) =>
+        mkWriterT<ListBox<number>, []>(
+            () =>
+                Promise.resolve(wrTuple([], cons(n)(nil()))) as unknown as import('data/kind').MinBox1<
+                    Tuple2Box<[], ListBox<number>>
+                >,
+        )
+
+    const valueWriter = mkWriterT<ListBox<number>, number>(
+        () =>
+            Promise.resolve(wrTuple(10, cons(1)(nil()))) as unknown as import('data/kind').MinBox1<
+                Tuple2Box<number, ListBox<number>>
+            >,
+    )
+
+    const programWriter = maybeTOverWriterMonad['>>='](liftWriterT(valueWriter), (x: number) =>
+        maybeTOverWriterMonad['>>='](liftWriterT(tellList(2)), () => maybeTOverWriterMonad.return(x + 5)),
+    )
+
+    const [maybeValue2, logList] = (await toPromise(
+        runWriterT(runMaybeTHelper(programWriter) as unknown as WriterTBox<ListBox<number>, MaybeBox<number>>),
+    )) as [MaybeBox<number>, ListBox<number>]
+    t.equal($case({ just: (x: number) => x })(maybeValue2), 15)
+    t.same(toArray(logList), [1, 2])
+})

--- a/test/data/bifunctor.builder.test.ts
+++ b/test/data/bifunctor.builder.test.ts
@@ -1,0 +1,20 @@
+import tap from 'tap'
+import { bifunctor as createBifunctor, BifunctorBase } from 'data/bifunctor'
+import { tuple2, fst, snd, Tuple2Box } from 'ghc/base/tuple/tuple'
+
+tap.test('Bifunctor builder (derive first/second from bimap)', async (t) => {
+    const base: BifunctorBase = {
+        bimap: <A, B, C, D>(f: (a: A) => C, g: (b: B) => D, pab: Tuple2Box<A, B>): Tuple2Box<C, D> =>
+            tuple2(f(fst(pab)), g(snd(pab))) as Tuple2Box<C, D>,
+    }
+
+    const BF = createBifunctor(base)
+
+    const pair = tuple2(2, 'x') as Tuple2Box<number, string>
+
+    const leftMapped = BF.first((n: number) => n + 1, pair) as Tuple2Box<number, string>
+    t.same([fst(leftMapped), snd(leftMapped)], [3, 'x'])
+
+    const rightMapped = BF.second((s: string) => s.toUpperCase(), pair) as Tuple2Box<number, string>
+    t.same([fst(rightMapped), snd(rightMapped)], [2, 'X'])
+})

--- a/test/ghc/base/applicative.builder.test.ts
+++ b/test/ghc/base/applicative.builder.test.ts
@@ -1,0 +1,44 @@
+import tap from 'tap'
+import { applicative as createApplicative } from 'ghc/base/applicative'
+import { functor as listFunctor } from 'ghc/base/list/functor'
+import { cons, nil, head, ListBox } from 'ghc/base/list/list'
+import { comp } from 'ghc/base/list/comprehension'
+
+tap.test('Applicative builder (derive missing pieces)', async (t) => {
+    t.test('derive liftA2 from <*>', async (t) => {
+        const base = {
+            pure: <A>(a: NonNullable<A>) => cons(a)(nil<NonNullable<A>>()),
+            '<*>': <A, B>(f: ListBox<(_: A) => B>, fa: ListBox<A>): ListBox<B> => comp((fn, a) => fn(a), [f, fa]),
+        }
+        const App = createApplicative(base, listFunctor)
+
+        const fa = cons<number>(2)(nil<number>())
+        const fb = cons<number>(3)(nil<number>())
+        const sum2 = (x: number) => (y: number) => x + y
+
+        // uses provided <*> and derived liftA2
+        const r1 = App['<*>'](cons<(x: number) => number>((x) => x + 5)(nil()), fa) as ListBox<number>
+        t.equal(head(r1), 7)
+
+        const r2 = App.liftA2(sum2, fa, fb) as ListBox<number>
+        t.equal(head(r2), 5)
+
+        // extensions
+        t.equal(head(App['*>'](fa, fb) as ListBox<number>), 3)
+        t.equal(head(App['<*'](fa, fb) as ListBox<number>), 2)
+        t.equal(head(App['<**>'](fa, cons<(n: number) => number>((n) => n * 10)(nil())) as ListBox<number>), 20)
+    })
+
+    t.test('derive <*> from liftA2', async (t) => {
+        const base = {
+            pure: <A>(a: NonNullable<A>) => cons(a)(nil<NonNullable<A>>()),
+            liftA2: <A, B, C>(f: (_: A) => (_: B) => C, fa: ListBox<A>, fb: ListBox<B>): ListBox<C> =>
+                comp((a, b) => f(a)(b), [fa, fb]),
+        }
+        const App = createApplicative(base, listFunctor)
+
+        const fa = cons<number>(4)(nil<number>())
+        const r1 = App['<*>'](cons<(x: number) => number>((x) => x - 1)(nil()), fa) as ListBox<number>
+        t.equal(head(r1), 3)
+    })
+})


### PR DESCRIPTION
New modules under src/control/monad/trans/... implement MaybeT and EitherT (and the ExceptT alias) including their Functor, Applicative, and Monad instances by lifting the underlying Monad operations and reusing the concrete Maybe/Either dictionaries. MonadTrans helpers are extended to expose maybeT, eitherT, and exceptT lifters with precise result types